### PR TITLE
Requirement Functions

### DIFF
--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -27,6 +27,8 @@ class DataValidation():
                         # it's just a category, so ignore it
                         if '@' in item:
                             continue
+                        if '$' in item:
+                            continue
 
                         item = item.replace("|", "")
 
@@ -40,13 +42,13 @@ class DataValidation():
 
                         if not item_exists:
                             raise ValidationError("Item %s is required by location %s but is misspelled or does not exist." % (item_name, location["name"]))
-                        
+
             else:  # item access is in dict form
                 for item in location["requires"]:
                     # if the require entry is an object with "or" or a list of items, treat it as a standalone require of its own
                     if (isinstance(item, dict) and "or" in item and isinstance(item["or"], list)) or (isinstance(item, list)):
                         or_items = item
-                        
+
                         if isinstance(item, dict):
                             or_items = item["or"]
 
@@ -64,7 +66,7 @@ class DataValidation():
                     else:
                         item_parts = item.split(":")
                         item_name = item
-                        
+
                         if len(item_parts) > 1:
                             item_name = item_parts[0]
 
@@ -103,13 +105,13 @@ class DataValidation():
 
                         if not item_exists:
                             raise ValidationError("Item %s is required by region %s but is misspelled or does not exist." % (item_name, region_name))
-                        
+
             else:  # item access is in dict form
                 for item in region["requires"]:
                     # if the require entry is an object with "or" or a list of items, treat it as a standalone require of its own
                     if (isinstance(item, dict) and "or" in item and isinstance(item["or"], list)) or (isinstance(item, list)):
                         or_items = item
-                        
+
                         if isinstance(item, dict):
                             or_items = item["or"]
 
@@ -127,7 +129,7 @@ class DataValidation():
                     else:
                         item_parts = item.split(":")
                         item_name = item
-                        
+
                         if len(item_parts) > 1:
                             item_name = item_parts[0]
 
@@ -143,7 +145,7 @@ class DataValidation():
                 continue
 
             region_exists = len([name for name in DataValidation.region_table if name == location["region"]]) > 0
-            
+
             if not region_exists:
                 raise ValidationError("Region %s is set for location %s, but the region is misspelled or does not exist." % (location["region"], location["name"]))
 
@@ -212,7 +214,7 @@ class DataValidation():
 
         if victory_count > 1:
             raise ValidationError("There are %s victory locations defined, but there should only be 1." % (str(victory_count)))
-        
+
     @staticmethod
     def checkForDuplicateItemNames():
         for item in DataValidation.item_table:
@@ -237,12 +239,12 @@ class DataValidation():
 
             if name_count > 1:
                 raise ValidationError("Region %s is defined more than once." % (region_name))
-            
+
     @staticmethod
     def checkStartingItemsForValidItemsAndCategories():
         if "starting_items" not in DataValidation.game_table:
             return
-        
+
         starting_items = DataValidation.game_table["starting_items"]
 
         for starting_block in starting_items:
@@ -253,7 +255,7 @@ class DataValidation():
                 for item_name in starting_block["items"]:
                     if not item_name in [item["name"] for item in DataValidation.item_table]:
                         raise ValidationError("Item %s is set as a starting item, but is misspelled or is not defined." % (item_name))
-            
+
             if "item_categories" in starting_block:
                 for category_name in starting_block["item_categories"]:
                     if len([item for item in DataValidation.item_table if "category" in item and category_name in item["category"]]) == 0:
@@ -268,12 +270,12 @@ class DataValidation():
     def checkForItemsBeingInvalidJSON():
         if len(DataValidation.item_table) == 0:
             raise ValidationError("No items were found in your items.json. This likely indicates that your JSON is incorrectly formatted. Use https://jsonlint.com/ to validate your JSON files.")
-        
+
     @staticmethod
     def checkForLocationsBeingInvalidJSON():
         if len(DataValidation.location_table) == 0:
             raise ValidationError("No locations were found in your locations.json. This likely indicates that your JSON is incorrectly formatted. Use https://jsonlint.com/ to validate your JSON files.")
-        
+
     @staticmethod
     def checkForGameFillerMatchingAnItemName():
         filler_item = DataValidation.game_table["filler_item_name"] or "Filler"
@@ -281,14 +283,14 @@ class DataValidation():
 
         if len(items_matching) > 0:
             raise ValidationError("Your game's filler item name ('%s') matches an item you defined in your items.json. Item names must be unique, including the default filler item." % (filler_item))
-        
+
     @staticmethod
     def checkForNonStartingRegionsThatAreUnreachable():
         using_starting_regions = len([region for region in DataValidation.region_table if "starting" in DataValidation.region_table[region] and not DataValidation.region_table[region]["starting"]]) > 0
 
         if not using_starting_regions:
             return
-        
+
         nonstarting_regions = [region for region in DataValidation.region_table if "starting" in DataValidation.region_table[region] and not DataValidation.region_table[region]["starting"]]
 
         for nonstarter in nonstarting_regions:

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -27,8 +27,6 @@ class DataValidation():
                         # it's just a category, so ignore it
                         if '@' in item:
                             continue
-                        if '$' in item:
-                            continue
 
                         item = item.replace("|", "")
 

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -1,7 +1,8 @@
 from worlds.generic.Rules import set_rule
 from .Regions import regionMap
+from .hooks import Rules
 from worlds.AutoWorld import World
-from BaseClasses import MultiWorld
+from BaseClasses import MultiWorld, CollectionState
 import re
 
 
@@ -61,7 +62,7 @@ def evaluate_postfix(expr, location):
 
 def set_rules(base: World, world: MultiWorld, player: int):
     # this is only called when the area (think, location or region) has a "requires" field that is a string
-    def checkRequireStringForArea(state, area):
+    def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
 
         # parse user written statement into list of each item
@@ -70,13 +71,16 @@ def set_rules(base: World, world: MultiWorld, player: int):
 
             if '|@' in item:
                 require_type = 'category'
+            elif '|$' in item:
+                require_type = 'function'
 
             item_base = item
-            item = item.replace('|', '').replace('@', '')
+            item = item.lstrip('|@$').rstrip('|')
 
             item_parts = item.split(":")
             item_name = item
             item_count = "1"
+
 
             if len(item_parts) > 1:
                 item_name = item_parts[0]
@@ -84,7 +88,15 @@ def set_rules(base: World, world: MultiWorld, player: int):
 
             total = 0
 
-            if require_type == 'category':
+            if require_type == 'function':
+                func = getattr(Rules, item_name)
+                if len(item_parts) > 1:
+                    result = func(base, world, state, player, item_parts[1])
+                else:
+                    result = func(base, world, state, player)
+                requires_list = requires_list.replace(item_base, "1" if result else "0")
+                continue
+            elif require_type == 'category':
                 category_items = [item for item in base.item_name_to_item.values() if "category" in item and item_name in item["category"]]
                 if item_count.lower() == 'all':
                     item_count = sum([int(base.item_name_to_item[category_item["name"]]['count']) for category_item in category_items])
@@ -121,7 +133,7 @@ def set_rules(base: World, world: MultiWorld, player: int):
         return (evaluate_postfix(requires_string, area))
 
     # this is only called when the area (think, location or region) has a "requires" field that is a dict
-    def checkRequireDictForArea(state, area):
+    def checkRequireDictForArea(state: CollectionState, area: dict):
         canAccess = True
 
         for item in area["requires"]:
@@ -163,7 +175,7 @@ def set_rules(base: World, world: MultiWorld, player: int):
         return canAccess
 
     # handle any type of checking needed, then ferry the check off to a dedicated method for that check
-    def fullLocationOrRegionCheck(state, area):
+    def fullLocationOrRegionCheck(state: CollectionState, area: dict):
         # if it's not a usable object of some sort, default to true
         if not area:
             return True
@@ -183,7 +195,7 @@ def set_rules(base: World, world: MultiWorld, player: int):
         used_location_names.extend([l.name for l in world.get_region(region, player).locations])
         if region != "Menu":
             for exitRegion in world.get_region(region, player).exits:
-                def fullRegionCheck(state, region=regionMap[region]):
+                def fullRegionCheck(state: CollectionState, region=regionMap[region]):
                     return fullLocationOrRegionCheck(state, region)
 
                 set_rule(world.get_entrance(exitRegion.name, player), fullRegionCheck)
@@ -198,7 +210,7 @@ def set_rules(base: World, world: MultiWorld, player: int):
         locationRegion = regionMap[location["region"]] if "region" in location else None
 
         if "requires" in location: # Location has requires, check them alongside the region requires
-            def checkBothLocationAndRegion(state, location=location, region=locationRegion):
+            def checkBothLocationAndRegion(state: CollectionState, location=location, region=locationRegion):
                 locationCheck = fullLocationOrRegionCheck(state, location)
                 regionCheck = True # default to true unless there's a region with requires
 

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -87,9 +87,9 @@ def set_rules(base: World, world: MultiWorld, player: int):
             if require_type == 'category':
                 category_items = [item for item in base.item_name_to_item.values() if "category" in item and item_name in item["category"]]
                 if item_count.lower() == 'all':
-                    item_count = sum([base.item_name_to_item[category_item["name"]]['count'] for category_item in category_items])
+                    item_count = sum([int(base.item_name_to_item[category_item["name"]]['count']) for category_item in category_items])
                 elif item_count.lower() == 'half':
-                    item_count = sum([base.item_name_to_item[category_item["name"]]['count'] for category_item in category_items]) / 2
+                    item_count = sum([int(base.item_name_to_item[category_item["name"]]['count']) for category_item in category_items]) / 2
                 else:
                     item_count = int(item_count)
 
@@ -100,9 +100,9 @@ def set_rules(base: World, world: MultiWorld, player: int):
                         requires_list = requires_list.replace(item_base, "1")
             elif require_type == 'item':
                 if item_count.lower() == 'all':
-                    item_count = base.item_name_to_item[item_name]['count']
+                    item_count = int(base.item_name_to_item[item_name]['count'])
                 elif item_count.lower() == 'half':
-                    item_count = base.item_name_to_item[item_name]['count'] / 2
+                    item_count = (base.item_name_to_item[item_name]['count']) / 2
                 else:
                     item_count = int(item_count)
 

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -35,7 +35,7 @@ def infix_to_postfix(expr, location):
     return postfix
 
 
-def evaluate_postfix(expr, location):
+def evaluate_postfix(expr: str, location: str) -> bool:
     stack = []
     try:
         for c in expr:
@@ -66,6 +66,8 @@ def set_rules(base: "ManualWorld", world: MultiWorld, player: int):
     # this is only called when the area (think, location or region) has a "requires" field that is a string
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
+        if requires_list == "":
+            return True
 
         for item in re.findall(r'\{(\w+)\(([^)]*)\)\}', area["requires"]):
             func_name = item[0]

--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -1,0 +1,20 @@
+from worlds.AutoWorld import World
+from BaseClasses import MultiWorld, CollectionState
+
+
+# Sometimes you have a requirement that is just too messy or repetitive to write out with boolean logic.
+# Define a function here, and you can use it in a requires string with |$function_name|.
+def overfishedAnywhere(world: World, mw: MultiWorld, state: CollectionState, player: int):
+    """Has the player collected all fish from any fishing log?"""
+    for cat, items in world.item_name_groups:
+        if cat.endswith("Fishing Log") and state.has_all(items, player):
+            return True
+    return False
+
+# You can also pass an argument to your function, like |$function_name:arg|
+def anyClassLevel(world: World, mw: MultiWorld, state: CollectionState, player: int, level: str):
+    """Has the player reached the given level in any class?"""
+    for item in ["Figher Level", "Black Belt Level", "Thief Level", "Red Mage Level", "White Mage Level", "Black Mage Level"]:
+        if state.count(item, player) >= int(level):
+            return True
+    return False

--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -3,7 +3,7 @@ from BaseClasses import MultiWorld, CollectionState
 
 
 # Sometimes you have a requirement that is just too messy or repetitive to write out with boolean logic.
-# Define a function here, and you can use it in a requires string with |$function_name|.
+# Define a function here, and you can use it in a requires string with (function_name()}.
 def overfishedAnywhere(world: World, mw: MultiWorld, state: CollectionState, player: int):
     """Has the player collected all fish from any fishing log?"""
     for cat, items in world.item_name_groups:
@@ -11,10 +11,16 @@ def overfishedAnywhere(world: World, mw: MultiWorld, state: CollectionState, pla
             return True
     return False
 
-# You can also pass an argument to your function, like |$function_name:arg|
+# You can also pass an argument to your function, like {function_name(15)}
+# Note that all arguments are strings, so you'll need to convert them to ints if you want to do math.
 def anyClassLevel(world: World, mw: MultiWorld, state: CollectionState, player: int, level: str):
     """Has the player reached the given level in any class?"""
     for item in ["Figher Level", "Black Belt Level", "Thief Level", "Red Mage Level", "White Mage Level", "Black Mage Level"]:
         if state.count(item, player) >= int(level):
             return True
     return False
+
+# You can also return a string from your function, and it will be evaluated as a requires string.
+def requiresMelee(world: World, mw: MultiWorld, state: CollectionState, player: int):
+    """Returns a requires string that checks if the player has unlocked the tank."""
+    return "|Figher Level:15| or |Black Belt Level:15| or |Thief Level:15|"


### PR DESCRIPTION
Sometimes you just don't want to type `|5 PLD Levels:7| or |5 WAR Levels:7| or |5 DRK Levels:7| or |5 GNB Levels:7| or |5 WHM Levels:7| or |5 SCH Levels:7| or |5 AST Levels:7| or |5 SGE Levels:7| or |5 MNK Levels:7| or |5 DRG Levels:7| or |5 NIN Levels:7| or |5 SAM Levels:7| or |5 RPR Levels:7| or |5 BRD Levels:7| or |5 MCH Levels:7| or |5 DNC Levels:7| or |5 BLM Levels:7| or |5 SMN Levels:7| or |5 RDM Levels:7| or |5 BLU Levels:7|` hundreds of times.

Also fixes a bug Rooby found when items.json has counts as strings.