### PR TITLE
Change fillers into a callable function

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -169,23 +169,7 @@ class ManualWorld(World):
                     self.multiworld.push_precollected(starting_item)
                     pool.remove(starting_item)
 
-        extras = len(self.multiworld.get_unfilled_locations(player=self.player)) - len(pool) - 1 # subtracting 1 because of Victory; seems right
-
-        if extras > 0:
-            trap_percent = get_option_value(self.multiworld, self.player, "filler_traps")
-            if not traps:
-                trap_percent = 0
-
-            trap_count = extras * trap_percent // 100
-            filler_count = extras - trap_count
-
-            for i in range(0, trap_count):
-                extra_item = self.create_item(self.random.choice(traps))
-                pool.append(extra_item)
-
-            for i in range(0, filler_count):
-                extra_item = self.create_item(filler_item_name)
-                pool.append(extra_item)
+        pool = self.add_filler_items(pool, traps)
 
         pool = before_generate_basic(pool, self, self.multiworld, self.player)
 
@@ -328,6 +312,26 @@ class ManualWorld(World):
         slot_data = after_fill_slot_data(slot_data, self, self.multiworld, self.player)
 
         return slot_data
+    
+    def add_filler_items(self, item_pool, traps):
+        extras = len(self.multiworld.get_unfilled_locations(player=self.player)) - len(item_pool) - 1 # subtracting 1 because of Victory; seems right
+
+        if extras > 0:
+            trap_percent = get_option_value(self.multiworld, self.player, "filler_traps")
+            if not traps:
+                trap_percent = 0
+
+            trap_count = extras * trap_percent // 100
+            filler_count = extras - trap_count
+
+            for i in range(0, trap_count):
+                extra_item = self.create_item(self.random.choice(traps))
+                item_pool.append(extra_item)
+
+            for i in range(0, filler_count):
+                extra_item = self.create_item(filler_item_name)
+                item_pool.append(extra_item)
+        return item_pool
 
     def client_data(self):
         return {


### PR DESCRIPTION
Turning the filler into a function means it can be called from a hook to enable better item handling.