### PR TITLE
Bug: Data Validation causes an error if filler_item_name is not used

### DIFF
--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -276,7 +276,7 @@ class DataValidation():
         
     @staticmethod
     def checkForGameFillerMatchingAnItemName():
-        filler_item = DataValidation.game_table["filler_item_name"] or "Filler"
+        filler_item = DataValidation.game_table["filler_item_name"] if "filler_item_name" in DataValidation.game_table else "Filler"
         items_matching = [item for item in DataValidation.item_table if item["name"] == filler_item]
 
         if len(items_matching) > 0:


### PR DESCRIPTION
It's intended that `filler_item_name` in game.json is optional and gets filled in for you with the value "Filler" if not present. However, DataValidation was referencing it in a way that expected it to be there. So this fixes the DataValidation to properly check for the key like Game.py does.