### PR TITLE
Client: Stop trimming colon suffixes from item name lookups

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -68,17 +68,6 @@ class ManualContext(SuperContext):
 
         self.location_names_to_id = dict([(value, key) for key, value in self.location_names.items()])
 
-        # if the item name has a number after it, remove it
-        for item_id, name in enumerate(self.item_names):
-            if not isinstance(name, str):
-                continue
-
-            name_parts = name.split(":")
-
-            if len(name_parts) > 1:
-                self.item_names.pop(name)
-                self.item_names[name_parts[0]] = item_id
-
         await self.get_username()
         await self.send_connect()
 
@@ -426,9 +415,8 @@ class ManualContext(SuperContext):
                                         item_data["category"] = ["(No Category)"]
 
                                     if category_name in item_data["category"] and network_item.item not in self.listed_items[category_name]:
-                                        item_name_parts = self.ctx.item_names[network_item.item].split(":")
                                         item_count = len(list(i for i in self.ctx.items_received if i.item == network_item.item))
-                                        item_text = Label(text="%s (%s)" % (item_name_parts[0], item_count),
+                                        item_text = Label(text="%s (%s)" % (item_name, item_count),
                                                     size_hint=(None, None), height=30, width=400, bold=True)
 
                                         category_grid.add_widget(item_text)


### PR DESCRIPTION
This is based on the (very) old way of defining item counts in Manual, where the `:X` count syntax used for requires now was actually the same way that you defined counts on items in the items.json, too. Since that's no longer the case, we don't need to trim `:X` from the end of item names in our item lookups.

Yes, their requires will still be broken for items with colon in the name. But at least receiving the item at all shouldn't break the client entirely.