### PR TITLE
Breaking change: Moving item creation to the create_items step

### DIFF
--- a/src/Data.py
+++ b/src/Data.py
@@ -5,8 +5,8 @@ import pkgutil
 from .DataValidation import DataValidation, ValidationError
 
 from .hooks.Data import \
-    after_load_item_file, after_load_progressive_item_file, \
-    after_load_location_file, after_load_region_file, after_load_category_file
+    after_load_item_file, after_load_location_file, \
+    after_load_region_file, after_load_category_file
 
 # blatantly copied from the minecraft ap world because why not
 def load_data_file(*args) -> dict:
@@ -21,15 +21,12 @@ def load_data_file(*args) -> dict:
 
 game_table = load_data_file('game.json')
 item_table = load_data_file('items.json')
-#progressive_item_table = load_data_file('progressive_items.json')
-progressive_item_table = {}
 location_table = load_data_file('locations.json')
 region_table = load_data_file('regions.json')
 category_table = load_data_file('categories.json') or {}
 
 # hooks
 item_table = after_load_item_file(item_table)
-progressive_item_table = after_load_progressive_item_file(progressive_item_table)
 location_table = after_load_location_file(location_table)
 region_table = after_load_region_file(region_table)
 category_table = after_load_category_file(category_table)
@@ -96,7 +93,6 @@ except ValidationError as e: validation_errors.append(e)
 # check for regions that are set as non-starting regions and have no connectors to them (so are unreachable)
 try: DataValidation.checkForNonStartingRegionsThatAreUnreachable()
 except ValidationError as e: validation_errors.append(e)
-
 
 
 ############

--- a/src/Items.py
+++ b/src/Items.py
@@ -1,10 +1,9 @@
 from BaseClasses import Item
-from .Data import item_table, progressive_item_table
+from .Data import item_table
 from .Game import filler_item_name, starting_index
-from .hooks.Items import before_item_table_processed, before_progressive_item_table_processed
+from .hooks.Items import before_item_table_processed
 
 item_table = before_item_table_processed(item_table)
-progressive_item_table = before_progressive_item_table_processed(progressive_item_table)
 
 ######################
 # Generate item lookups
@@ -34,8 +33,6 @@ for item in item_table:
     item_name = item["name"]
     item_id_to_name[item["id"]] = item_name
     item_name_to_item[item_name] = item
-    if item["progression"]:
-        advancement_item_names.add(item_name)
 
     if item["id"] is not None:
         lastItemId = max(lastItemId, item["id"])
@@ -44,23 +41,6 @@ for item in item_table:
         if c not in item_name_groups:
             item_name_groups[c] = []
         item_name_groups[c].append(item_name)
-
-progressive_item_list = {}
-
-for item in progressive_item_table:
-    progressiveName = progressive_item_table[item]
-    if progressiveName not in progressive_item_list:
-        progressive_item_list[progressiveName] = []
-    progressive_item_list[progressiveName].append(item)
-
-for progressiveItemName in progressive_item_list.keys():
-    lastItemId += 1
-    generatedItem = {}
-    generatedItem["id"] = lastItemId
-    generatedItem["name"] = progressiveItemName
-    generatedItem["progression"] = item_name_to_item[progressive_item_list[progressiveItemName][0]]["progression"]
-    item_name_to_item[progressiveItemName] = generatedItem
-    item_id_to_name[lastItemId] = progressiveItemName
 
 item_id_to_name[None] = "__Victory__"
 item_name_to_id = {name: id for id, name in item_id_to_name.items()}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,10 +6,10 @@ from typing import Callable, Optional
 from worlds.generic.Rules import forbid_items_for_player
 from worlds.LauncherComponents import Component, SuffixIdentifier, components, Type, launch_subprocess
 
-from .Data import item_table, progressive_item_table, location_table, region_table, category_table
+from .Data import item_table, location_table, region_table, category_table
 from .Game import game_name, filler_item_name, starting_items
 from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups
-from .Items import item_id_to_name, item_name_to_id, item_name_to_item, advancement_item_names, item_name_groups
+from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups
 
 from .Regions import create_regions
 from .Items import ManualItem
@@ -21,11 +21,11 @@ from BaseClasses import ItemClassification, Tutorial, Item
 from worlds.AutoWorld import World, WebWorld
 
 from .hooks.World import \
-    before_pre_fill, after_pre_fill, \
-    before_generate_basic, after_generate_basic, \
+    before_create_regions, after_create_regions, \
+    before_create_items, after_create_items, \
     before_create_item, after_create_item, \
     before_set_rules, after_set_rules, \
-    before_create_regions, after_create_regions, \
+    before_generate_basic, after_generate_basic, \
     before_fill_slot_data, after_fill_slot_data
 
 class ManualWeb(WebWorld):
@@ -37,7 +37,6 @@ class ManualWeb(WebWorld):
         "setup/en",
         ["Fuzzy"]
     )]
-
 
 class ManualWorld(World):
     """
@@ -55,21 +54,23 @@ class ManualWorld(World):
 
     # These properties are set from the imports of the same name above.
     item_table = item_table
+    location_table = location_table # this is likely imported from Data instead of Locations because the Game Complete location should not be in here, but is used for lookups
     category_table = category_table
-    progressive_item_table = progressive_item_table
+
     item_id_to_name = item_id_to_name
     item_name_to_id = item_name_to_id
     item_name_to_item = item_name_to_item
     item_name_groups = item_name_groups
-    advancement_item_names = advancement_item_names
-    location_table = location_table # this is likely imported from Data instead of Locations because the Game Complete location should not be in here, but is used for lookups
+    
     location_id_to_name = location_id_to_name
     location_name_to_id = location_name_to_id
     location_name_to_location = location_name_to_location
     location_name_groups = location_name_groups
 
-    def pre_fill(self):
-        before_pre_fill(self, self.multiworld, self.player)
+    def create_regions(self):
+        before_create_regions(self, self.multiworld, self.player)
+
+        create_regions(self, self.multiworld, self.player)
 
         location_game_complete = self.multiworld.get_location("__Manual Game Complete__", self.player)
         location_game_complete.address = None
@@ -77,64 +78,48 @@ class ManualWorld(World):
         location_game_complete.place_locked_item(
             ManualItem("__Victory__", ItemClassification.progression, None, player=self.player))
 
-        after_pre_fill(self, self.multiworld, self.player)
+        after_create_regions(self, self.multiworld, self.player)
 
-    def generate_basic(self):
+    def create_items(self):
         # Generate item pool
         pool = []
         traps = []
         configured_item_names = self.item_id_to_name.copy()
 
         for name in configured_item_names.values():
-            if name == "__Victory__":
-                continue
-
-            # If it's the filler item, skip it until we know if we need any extra items
-            if name == filler_item_name:
-                continue
-
-            # if (hasattr(self.multiworld, "progressive_items") and len(self.multiworld.progressive_items) > 0):
-            #     shouldUseProgressive = (self.multiworld.progressive_items[self.player].value);
-
-            #     if shouldUseProgressive and name in self.progressive_item_table:
-            #         name = self.progressive_item_table[name]
+            if name == "__Victory__": continue
+            if name == filler_item_name: continue
 
             item = self.item_name_to_item[name]
-            item_count = 1
+            item_count = int(item.get("count") or 1)
 
             if item.get("trap"):
                 traps.append(name)
 
-            if "count" in item:
-                item_count = int(item["count"])
-
             if "category" in item:
-                for category in item.get("category", []):
-                    if not is_category_enabled(self.multiworld, self.player, category):
-                        item_count = 0
-                        break
+                any_categories_disabled = [cat for cat in item.get("category", []) if not is_category_enabled(self.multiworld, self.player, cat)]
 
-            if item_count == 0:
-                continue
+                if len(any_categories_disabled) > 0:
+                    item_count = 0
+                    break
+                
+            if item_count == 0: continue
 
             for i in range(item_count):
                 new_item = self.create_item(name)
                 pool.append(new_item)
 
-            if item.get("early") and item.get("local"):
-              # both
+            if item.get("early") and item.get("local"): # both
                 self.multiworld.local_early_items[self.player][name] = item_count
-
-            elif item.get("early"):
-                # only early
+            elif item.get("early"): # only early
                 self.multiworld.early_items[self.player][name] = item_count
-
-            elif item.get("local"):
-              # only local
+            elif item.get("local"): # only local
                 if name not in self.multiworld.local_items[self.player].value:
                     self.multiworld.local_items[self.player].value.add(name)
 
         items_started = []
+
+        pool = before_create_items(pool, self, self.multiworld, self.player)
 
         if starting_items:
             for starting_item_block in starting_items:
@@ -171,11 +156,46 @@ class ManualWorld(World):
 
         pool = self.add_filler_items(pool, traps)
 
-        pool = before_generate_basic(pool, self, self.multiworld, self.player)
+        pool = after_create_items(pool, self, self.multiworld, self.player)
 
         # need to put all of the items in the pool so we can have a full state for placement
         # then will remove specific item placements below from the overall pool
         self.multiworld.itempool += pool
+
+    def create_item(self, name: str) -> Item:
+        name = before_create_item(name, self, self.multiworld, self.player)
+
+        item = self.item_name_to_item[name]
+        classification = ItemClassification.filler
+
+        if "trap" in item and item["trap"]:
+            classification = ItemClassification.trap
+
+        if "useful" in item and item["useful"]:
+            classification = ItemClassification.useful
+
+        if "progression" in item and item["progression"]:
+            classification = ItemClassification.progression
+
+        if "progression_skip_balancing" in item and item["progression_skip_balancing"]:
+            classification = ItemClassification.progression_skip_balancing
+
+        item_object = ManualItem(name, classification,
+                        self.item_name_to_id[name], player=self.player)
+
+        item_object = after_create_item(item_object, self, self.multiworld, self.player)
+
+        return item_object
+    
+    def set_rules(self):
+        before_set_rules(self, self.multiworld, self.player)
+
+        set_rules(self, self.multiworld, self.player)
+
+        after_set_rules(self, self.multiworld, self.player)
+
+    def generate_basic(self):
+        before_generate_basic(self, self.multiworld, self.player)
 
         # Handle item forbidding
         manual_locations_with_forbid = {location['name']: location for location in location_name_to_location.values() if "dont_place_item" in location or "dont_place_item_category" in location}
@@ -265,45 +285,6 @@ class ManualWorld(World):
         # from Utils import visualize_regions
         # visualize_regions(self.multiworld.get_region("Menu", self.player), f"{self.game}.puml")
 
-    def create_item(self, name: str) -> Item:
-        name = before_create_item(name, self, self.multiworld, self.player)
-
-        item = self.item_name_to_item[name]
-        classification = ItemClassification.filler
-
-        if "trap" in item and item["trap"]:
-            classification = ItemClassification.trap
-
-        if "useful" in item and item["useful"]:
-            classification = ItemClassification.useful
-
-        if "progression" in item and item["progression"]:
-            classification = ItemClassification.progression
-
-        if "progression_skip_balancing" in item and item["progression_skip_balancing"]:
-            classification = ItemClassification.progression_skip_balancing
-
-        item_object = ManualItem(name, classification,
-                        self.item_name_to_id[name], player=self.player)
-
-        item_object = after_create_item(item_object, self, self.multiworld, self.player)
-
-        return item_object
-
-    def set_rules(self):
-        before_set_rules(self, self.multiworld, self.player)
-
-        set_rules(self, self.multiworld, self.player)
-
-        after_set_rules(self, self.multiworld, self.player)
-
-    def create_regions(self):
-        before_create_regions(self, self.multiworld, self.player)
-
-        create_regions(self, self.multiworld, self.player)
-
-        after_create_regions(self, self.multiworld, self.player)
-
     def fill_slot_data(self):
         slot_data = before_fill_slot_data({}, self, self.multiworld, self.player)
 
@@ -313,6 +294,10 @@ class ManualWorld(World):
 
         return slot_data
     
+    ###
+    # Non-standard AP world methods
+    ###
+
     def add_filler_items(self, item_pool, traps):
         extras = len(self.multiworld.get_unfilled_locations(player=self.player)) - len(item_pool) - 1 # subtracting 1 because of Victory; seems right
 
@@ -342,8 +327,7 @@ class ManualWorld(World):
             'locations': self.location_name_to_location,
             # todo: extract connections out of mutliworld.get_regions() instead, in case hooks have modified the regions.
             'regions': region_table,
-            'categories': category_table,
-
+            'categories': category_table
         }
 
     def generate_output(self, output_directory: str):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -91,7 +91,7 @@ class ManualWorld(World):
             if name == filler_item_name: continue
 
             item = self.item_name_to_item[name]
-            item_count = int(item.get("count") or 1)
+            item_count = int(item.get("count", 1))
 
             if item.get("trap"):
                 traps.append(name)
@@ -294,6 +294,12 @@ class ManualWorld(World):
 
         return slot_data
     
+    def generate_output(self, output_directory: str):
+        data = self.client_data()
+        filename = f"{self.multiworld.get_out_file_name_base(self.player)}.apmanual"
+        with open(os.path.join(output_directory, filename), 'wb') as f:
+            f.write(b64encode(bytes(json.dumps(data), 'utf-8')))
+    
     ###
     # Non-standard AP world methods
     ###
@@ -332,12 +338,9 @@ class ManualWorld(World):
             'categories': category_table
         }
 
-    def generate_output(self, output_directory: str):
-        data = self.client_data()
-        filename = f"{self.multiworld.get_out_file_name_base(self.player)}.apmanual"
-        with open(os.path.join(output_directory, filename), 'wb') as f:
-            f.write(b64encode(bytes(json.dumps(data), 'utf-8')))
-
+###
+# Non-world client methods
+###
 
 def launch_client(*args):
     from .ManualClient import launch as Main

--- a/src/hooks/Items.py
+++ b/src/hooks/Items.py
@@ -3,8 +3,3 @@
 # if you need access to the items after processing to add ids, etc., you should use the hooks in World.py
 def before_item_table_processed(item_table: list) -> list:
     return item_table
-
-# NOTE: Progressive items are not currently supported in Manual. Once they are, 
-#       this hook will provide the ability to meaningfully change those.
-def before_progressive_item_table_processed(progressive_item_table: list) -> list:
-    return progressive_item_table

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -30,7 +30,7 @@ from ..Helpers import is_option_enabled, get_option_value
 
 
 
-# Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included.
+# Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):
     pass
 

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -1,6 +1,6 @@
 # Object classes from AP core, to represent an entire MultiWorld and this individual World that's part of it
 from worlds.AutoWorld import World
-from BaseClasses import MultiWorld
+from BaseClasses import MultiWorld, CollectionState
 
 # Object classes from Manual -- extending AP core -- representing items and locations that are used in generation
 from ..Items import ManualItem
@@ -49,12 +49,12 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     if hasattr(multiworld, "clear_location_cache"):
         multiworld.clear_location_cache()
 
-# The item pool before starting items are processed, in case you want to see the full raw item pool
-def before_create_items(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
-    pass
+# The item pool before starting items are processed, in case you want to see the raw item pool at that stage
+def before_create_items_starting(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
+    return item_pool
 
-# The complete item pool prior to being set for generation is provided here, in case you want to make changes to it
-def after_create_items(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
+# The item pool after starting items are processed but before filler is added, in case you want to see the raw item pool at that stage
+def before_create_items_filler(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
     # Use this hook to remove items from the item pool
     itemNamesToRemove = [] # List of item names
     
@@ -76,6 +76,10 @@ def after_create_items(item_pool: list, world: World, multiworld: MultiWorld, pl
     # item_to_place = next(i for i in item_pool if i.name == "Item Name")
     # location.place_locked_item(item_to_place)
     # item_pool.remove(item_to_place)
+
+# The complete item pool prior to being set for generation is provided here, in case you want to make changes to it
+def after_create_items(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
+    return item_pool
 
 # Called before rules for accessing regions and locations are created. Not clear why you'd want this, but it's here.
 def before_set_rules(world: World, multiworld: MultiWorld, player: int):

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -19,9 +19,10 @@ from ..Helpers import is_option_enabled, get_option_value
 ########################################################################################
 ## Order of method calls when the world generates:
 ##    1. create_regions - Creates regions and locations
-##    2. set_rules - Creates rules for accessing regions and locations
-##    3. generate_basic - Creates the item pool and runs any place_item options
-##    4. pre_fill - Creates the victory location
+##    2. create_items - Creates the item pool
+##    3. set_rules - Creates rules for accessing regions and locations
+##    4. generate_basic - Runs any post item pool options, like place item/category
+##    5. pre_fill - Creates the victory location
 ##
 ## The create_item method is used by plando and start_inventory settings to create an item from an item name.
 ## The fill_slot_data method will be used to send data to the Manual client for later use, like deathlink.
@@ -29,11 +30,11 @@ from ..Helpers import is_option_enabled, get_option_value
 
 
 
-# Called before regions and locations are created. Not clear why you'd want this, but it's here.
+# Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included.
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):
     pass
 
-# Called after regions and locations are created, in case you want to see or modify that information.
+# Called after regions and locations are created, in case you want to see or modify that information. Victory location is included.
 def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     # Use this hook to remove locations from the world
     locationNamesToRemove = [] # List of location names
@@ -47,6 +48,34 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
                     region.locations.remove(location)
     if hasattr(multiworld, "clear_location_cache"):
         multiworld.clear_location_cache()
+
+# The item pool before starting items are processed, in case you want to see the full raw item pool
+def before_create_items(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
+    pass
+
+# The complete item pool prior to being set for generation is provided here, in case you want to make changes to it
+def after_create_items(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
+    # Use this hook to remove items from the item pool
+    itemNamesToRemove = [] # List of item names
+    
+    # Add your code here to calculate which items to remove.
+    # 
+    # Because multiple copies of an item can exist, you need to add an item name
+    # to the list multiple times if you want to remove multiple copies of it.
+    
+    for itemName in itemNamesToRemove:
+        item = next(i for i in item_pool if i.name == itemName)
+        item_pool.remove(item)
+    
+    return item_pool
+    
+    # Some other useful hook options:
+    
+    ## Place an item at a specific location
+    # location = next(l for l in multiworld.get_unfilled_locations(player=player) if l.name == "Location Name")
+    # item_to_place = next(i for i in item_pool if i.name == "Item Name")
+    # location.place_locked_item(item_to_place)
+    # item_pool.remove(item_to_place)
 
 # Called before rules for accessing regions and locations are created. Not clear why you'd want this, but it's here.
 def before_set_rules(world: World, multiworld: MultiWorld, player: int):
@@ -72,42 +101,6 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     # OR
     # location.access_rule = lambda state: old_rule(state) or Example_Rule(state)
 
-# The complete item pool prior to being set for generation is provided here, in case you want to make changes to it
-def before_generate_basic(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
-    # Use this hook to remove items from the item pool
-    itemNamesToRemove = [] # List of item names
-    
-    # Add your code here to calculate which items to remove.
-    # 
-    # Because multiple copies of an item can exist, you need to add an item name
-    # to the list multiple times if you want to remove multiple copies of it.
-    
-    for itemName in itemNamesToRemove:
-        item = next(i for i in item_pool if i.name == itemName)
-        item_pool.remove(item)
-    
-    return item_pool
-    
-    # Some other useful hook options:
-    
-    ## Place an item at a specific location
-    # location = next(l for l in multiworld.get_unfilled_locations(player=player) if l.name == "Location Name")
-    # item_to_place = next(i for i in item_pool if i.name == "Item Name")
-    # location.place_locked_item(item_to_place)
-    # item_pool.remove(item_to_place)
-
-# This method is run at the very end of pre-generation, once the place_item options have been handled and before AP generation occurs
-def after_generate_basic(world: World, multiworld: MultiWorld, player: int):
-    pass
-
-# This method is called before the victory location has the victory event placed and locked
-def before_pre_fill(world: World, multiworld: MultiWorld, player: int):
-    pass
-
-# This method is called after the victory location has the victory event placed and locked
-def after_pre_fill(world: World, multiworld: MultiWorld, player: int):
-    pass
-
 # The item name to create is provided before the item is created, in case you want to make changes to it
 def before_create_item(item_name: str, world: World, multiworld: MultiWorld, player: int) -> str:
     return item_name
@@ -115,6 +108,14 @@ def before_create_item(item_name: str, world: World, multiworld: MultiWorld, pla
 # The item that was created is provided after creation, in case you want to modify the item
 def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, player: int) -> ManualItem:
     return item
+
+# This method is run towards the end of pre-generation, before the place_item options have been handled and before AP generation occurs
+def before_generate_basic(world: World, multiworld: MultiWorld, player: int) -> list:
+    pass
+
+# This method is run at the very end of pre-generation, once the place_item options have been handled and before AP generation occurs
+def after_generate_basic(world: World, multiworld: MultiWorld, player: int):
+    pass
 
 # This is called before slot data is set and provides an empty dict ({}), in case you want to modify it before Manual does
 def before_fill_slot_data(slot_data: dict, world: World, multiworld: MultiWorld, player: int) -> dict:


### PR DESCRIPTION
This is something that's needed to be adjusted for a while. Currently, Manual creates its item pool in generate_basic, but it really should be created in create_items, since that's what it's there for. generate_basic is more there for post item pool things.

So this PR changes that. Some of the specific changes:
- There are now two hooks to replace before_generate_basic: before_create_items_starting and before_create_items_filler
   - That way, people can hook before whichever process they want during item creation
- The victory location and its event are now setup during create_regions instead of pre_fill, as another "what it's there for" change
- generate_basic now just handles place and don't place.

Updated all the hook templates and created new hooks for create_items, and took item pool out of generate basic hooks.

(As an aside, took out progressive items, since they were never implemented.)
