### PR TITLE
Yaml options Part two:  Negated requirements

### DIFF
--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -23,6 +23,11 @@ def is_category_enabled(world: MultiWorld, player: int, category_name: str) -> b
     category_data = category_table.get(category_name, {})
     if "yaml_option" in category_data:
         for option_name in category_data["yaml_option"]:
-            if not is_option_enabled(world, player, option_name):
+            required = True
+            if option_name.startswith("!"):
+                option_name = option_name[1:]
+                required = False
+
+            if is_option_enabled(world, player, option_name) != required:
                 return False
     return True

--- a/src/Options.py
+++ b/src/Options.py
@@ -14,6 +14,8 @@ manual_options["filler_traps"] = FillerTrapPercent
 
 for category in category_table:
     for option_name in category_table[category].get("yaml_option", []):
+        if option_name[0] == "!":
+            option_name = option_name[1:]
         if option_name not in manual_options:
             manual_options[option_name] = type(option_name, (Toggle,), {"default": True})
 


### PR DESCRIPTION
Fairly simple feature here.  Allows a category to require a yaml setting to be false.