### PR TITLE
Client: Make client reassign IDs based on datapackage

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -80,7 +80,6 @@ class ManualContext(SuperContext):
         if not location:
             # It is absolutely possible to pull categories from the data_package via self.update_game. I have not done this yet.
             location = AutoWorldRegister.world_types[self.game].location_name_to_location.get(name, {"name": name})
-        location["id"] = self.location_names_to_id.get(name)
         return location
 
     def get_location_by_id(self, id):
@@ -91,7 +90,6 @@ class ManualContext(SuperContext):
         item = self.item_table.get(name)
         if not item:
             item = AutoWorldRegister.world_types[self.game].item_name_to_item.get(name, {"name": name})
-        item["id"] = self.item_names_to_id.get(name)
         return item
 
     def get_item_by_id(self, id):
@@ -401,8 +399,9 @@ class ManualContext(SuperContext):
                                         # Get the item name from the item Label, minus quantity, then do a lookup for count
                                         old_item_text = item.text
                                         item_name = re.sub("\s\(\d+\)$", "", item.text)
+                                        item_id = self.ctx.item_names_to_id[item_name]
                                         item_data = self.ctx.get_item_by_name(item_name)
-                                        item_count = len(list(i for i in self.ctx.items_received if i.item == item_data["id"]))
+                                        item_count = len(list(i for i in self.ctx.items_received if i.item == item_id))
 
                                         # Update the label quantity
                                         item.text="%s (%s)" % (item_name, item_count)

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -408,7 +408,6 @@ class ManualContext(SuperContext):
                                         old_item_text = item.text
                                         item_name = re.sub("\s\(\d+\)$", "", item.text)
                                         item_id = self.ctx.item_names_to_id[item_name]
-                                        item_data = self.ctx.get_item_by_name(item_name)
                                         item_count = len(list(i for i in self.ctx.items_received if i.item == item_id))
 
                                         # Update the label quantity

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -67,6 +67,7 @@ class ManualContext(SuperContext):
             raise Exception(f"Cannot load {self.game}, please add the apworld to lib/worlds/")
 
         self.location_names_to_id = dict([(value, key) for key, value in self.location_names.items()])
+        self.item_names_to_id = dict([(value, key) for key, value in self.item_names.items()])
 
         await self.get_username()
         await self.send_connect()
@@ -76,10 +77,11 @@ class ManualContext(SuperContext):
 
     def get_location_by_name(self, name):
         location = self.location_table.get(name)
-        if location:
-            return location
-        # It is absolutely possible to pull categories from the data_package via self.update_game. I have not done this yet.
-        return AutoWorldRegister.world_types[self.game].location_name_to_location.get(name, {"name": name})
+        if not location:
+            # It is absolutely possible to pull categories from the data_package via self.update_game. I have not done this yet.
+            location = AutoWorldRegister.world_types[self.game].location_name_to_location.get(name, {"name": name})
+        location["id"] = self.location_names_to_id.get(name)
+        return location
 
     def get_location_by_id(self, id):
         name = self.location_names[id]
@@ -87,9 +89,14 @@ class ManualContext(SuperContext):
 
     def get_item_by_name(self, name):
         item = self.item_table.get(name)
-        if item:
-            return item
-        return AutoWorldRegister.world_types[self.game].item_name_to_item.get(name, {"name": name})
+        if not item:
+            item = AutoWorldRegister.world_types[self.game].item_name_to_item.get(name, {"name": name})
+        item["id"] = self.item_names_to_id.get(name)
+        return item
+
+    def get_item_by_id(self, id):
+        name = self.item_names[id]
+        return self.get_item_by_name(name)
 
     @property
     def endpoints(self):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -360,7 +360,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 20240125 # YYYYMMDD
+    version = 20240128 # YYYYMMDD
     found = False
     for c in components:
         if c.display_name == "Manual Client":


### PR DESCRIPTION
Brazenly empowered by #10, I started doing more aggressive improvements to an in-progress apworld, which exposed new flaws.

This update syncs the network IDs back into your item and location tables, overwriting the ones generated at load time.  Which prevents issues where inserting a new item halfway down your json file causes everything later in the file to take on the wrong name.