### PR TITLE
Requires functions fix

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -81,7 +81,7 @@ def set_rules(base: "ManualWorld", world: MultiWorld, player: int):
         if requires_list == "":
             return True
 
-        for item in re.findall(r'\{(\w+)\(([^)]*)\)\}', area["requires"]):
+        for item in re.findall(r'\{(\w+)\(([^)]*)\)\}', requires_list):
             func_name = item[0]
             func_args = item[1].split(",")
             func = getattr(Rules, func_name)
@@ -93,7 +93,7 @@ def set_rules(base: "ManualWorld", world: MultiWorld, player: int):
 
 
         # parse user written statement into list of each item
-        for item in re.findall(r'\|[^|]+\|', area["requires"]):
+        for item in re.findall(r'\|[^|]+\|', requires_list):
             require_type = 'item'
 
             if '|@' in item:

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -64,8 +64,6 @@ def evaluate_postfix(expr: str, location: str) -> bool:
         raise KeyError("Invalid logic format for location/region {}.".format(location))
     return stack.pop()
 
-
-
 def set_rules(base: "ManualWorld", world: MultiWorld, player: int):
     # this is only called when the area (think, location or region) has a "requires" field that is a string
     def checkRequireStringForArea(state: CollectionState, area: dict):
@@ -76,7 +74,7 @@ def set_rules(base: "ManualWorld", world: MultiWorld, player: int):
             base.item_counts[player] = {i.name: real_pool.count(i) for i in real_pool if i.player == player}
 
         # fallback if items_counts[player] not present (will not be accurate to hooks item count)
-        items_counts = base.item_counts.get(player)
+        items_counts = base.get_item_counts()
 
         if requires_list == "":
             return True

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -332,6 +332,15 @@ class ManualWorld(World):
 
         return item_pool
 
+    def get_item_counts(self, player: Optional[int] = None, reset: bool = False) -> dict:
+        """returns the player real item count"""
+        if player == None:
+            player = self.player
+        if player not in self.item_counts or reset:
+            real_pool = self.multiworld.get_items()
+            self.item_counts[player] = {i.name: real_pool.count(i) for i in real_pool if i.player == player}
+        return self.item_counts.get(player)
+
     def client_data(self):
         return {
             "game": self.game,

--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -1,6 +1,9 @@
+from typing import Optional
 from worlds.AutoWorld import World
+from ..Helpers import clamp
 from BaseClasses import MultiWorld, CollectionState
 
+import re
 
 # Sometimes you have a requirement that is just too messy or repetitive to write out with boolean logic.
 # Define a function here, and you can use it in a requires string with (function_name()}.
@@ -24,3 +27,72 @@ def anyClassLevel(world: World, mw: MultiWorld, state: CollectionState, player: 
 def requiresMelee(world: World, mw: MultiWorld, state: CollectionState, player: int):
     """Returns a requires string that checks if the player has unlocked the tank."""
     return "|Figher Level:15| or |Black Belt Level:15| or |Thief Level:15|"
+
+# Two useful functions to make require work if an item is disabled instead of making it inaccessible
+# OptOne check if the passed item (with or without ||) is enabled, then return |item:count| where count is clamped to the maximum number of said item
+def OptOne(base: World, world: MultiWorld, state: CollectionState, player: int, item: str, items_counts: Optional[dict] = None):
+    """Returns item with count adjusted to Real Item Count"""
+    if item == "":
+        return "" #Skip this function if item is left blank
+    if not items_counts:
+        items_counts = _getItem_counts(base, world, player)
+
+    require_type = 'item'
+
+    if '@' in item[:2]:
+        require_type = 'category'
+
+    item = item.lstrip('|@$').rstrip('|')
+
+    item_parts = item.split(":")
+    item_name = item
+    item_count = 1
+
+    if len(item_parts) > 1:
+        item_name = item_parts[0]
+        item_count = item_parts[1]
+
+    if require_type == 'category':
+        if isinstance(item_count, int):
+            #Only loop if we can use the result to clamp
+            category_items = [item for item in base.item_name_to_item.values() if "category" in item and item_name in item["category"]]
+            category_items_counts = sum([items_counts.get(category_item["name"], 0) for category_item in category_items])
+            item_count = clamp(item_count, 0, category_items_counts)
+        return f"|@{item_name}:{item_count}|"
+    elif require_type == 'item':
+        if isinstance(item_count, int):
+            item_current_count = items_counts.get(item_name, 0)
+            item_count = clamp(item_count, 0, item_current_count)
+        return f"|{item_name}:{item_count}|"
+
+# OptAll check the passed require string and loop every item to check if they're enabled,
+# then returns the require string with counts ajusted using OptOne
+def OptAll(base: World, world: MultiWorld, state: CollectionState, player: int, requires: str):
+    """Returns an entire require string with counts adjusted to Real Item Count"""
+    requires_list = requires
+
+    items_counts = _getItem_counts(base, world, player)
+
+    functions = {}
+    if requires_list == "":
+        return True
+    for item in re.findall(r'\{(\w+)\(([^)]*)\)\}', requires_list):
+        #so this function doesnt try to get item from other functions, in theory.
+        func_name = item[0]
+        functions[func_name] = item[1]
+        requires_list = requires_list.replace("{" + func_name + "(" + item[1] + ")}", "{" + func_name + "(temp)}")
+    # parse user written statement into list of each item
+    for item in re.findall(r'\|[^|]+\|', requires):
+        itemScanned = OptOne(base, world, state, player, item, items_counts)
+        requires_list = requires_list.replace(item, itemScanned)
+
+    for function in functions:
+        requires_list = requires_list.replace("{" + function + "(temp)}", "{" + func_name + "(" + functions[func_name] + ")}")
+    return requires_list
+
+def _getItem_counts(base: World, world: MultiWorld, player: int):
+    """Private method that returns the players real item count"""
+    if player not in base.item_counts:
+        real_pool = world.get_items()
+        base.item_counts[player] = {i.name: real_pool.count(i) for i in real_pool if i.player == player}
+    return base.item_counts.get(player)

--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -35,7 +35,7 @@ def OptOne(base: World, world: MultiWorld, state: CollectionState, player: int, 
     if item == "":
         return "" #Skip this function if item is left blank
     if not items_counts:
-        items_counts = _getItem_counts(base, world, player)
+        items_counts = base.get_item_counts()
 
     require_type = 'item'
 
@@ -71,7 +71,7 @@ def OptAll(base: World, world: MultiWorld, state: CollectionState, player: int, 
     """Returns an entire require string with counts adjusted to Real Item Count"""
     requires_list = requires
 
-    items_counts = _getItem_counts(base, world, player)
+    items_counts = base.get_item_counts()
 
     functions = {}
     if requires_list == "":
@@ -90,9 +90,3 @@ def OptAll(base: World, world: MultiWorld, state: CollectionState, player: int, 
         requires_list = requires_list.replace("{" + function + "(temp)}", "{" + func_name + "(" + functions[func_name] + ")}")
     return requires_list
 
-def _getItem_counts(base: World, world: MultiWorld, player: int):
-    """Private method that returns the players real item count"""
-    if player not in base.item_counts:
-        real_pool = world.get_items()
-        base.item_counts[player] = {i.name: real_pool.count(i) for i in real_pool if i.player == player}
-    return base.item_counts.get(player)


### PR DESCRIPTION
Function would make generation crash if `||` is used in a function arguments since we reused the raw `area["requires"]`
instead of using `requires_list` that has been modified by the functions

I also Included the functions I made to allow optionnal items, and since its a function the creator must conscientiously choose to use them instead of just a symbol or new item parameters.

if its not something we want tell me and ill revert the comit with those (or delete them if its simpler)