### PR TITLE
Defer heavier Data Validation until a world is actually used

### DIFF
--- a/src/Data.py
+++ b/src/Data.py
@@ -49,66 +49,6 @@ except ValidationError as e: validation_errors.append(e)
 try: DataValidation.checkForLocationsBeingInvalidJSON()
 except ValidationError as e: validation_errors.append(e)
 
-# check that requires have correct item names in locations and regions
-try: DataValidation.checkItemNamesInLocationRequires()
-except ValidationError as e: validation_errors.append(e)
-
-try: DataValidation.checkItemNamesInRegionRequires()
-except ValidationError as e: validation_errors.append(e)
-
-# check that region names are correct in locations
-try: DataValidation.checkRegionNamesInLocations()
-except ValidationError as e: validation_errors.append(e)
-
-# check that items that are required by locations and regions are also marked required
-try: DataValidation.checkItemsThatShouldBeRequired()
-except ValidationError as e: validation_errors.append(e)
-
-# check that regions that are connected to are correct
-try: DataValidation.checkRegionsConnectingToOtherRegions()
-except ValidationError as e: validation_errors.append(e)
-
-# check that the apworld creator didn't specify multiple victory conditions
-try: DataValidation.checkForMultipleVictoryLocations()
-except ValidationError as e: validation_errors.append(e)
-
-# check for duplicate names in items, locations, and regions
-try: DataValidation.checkForDuplicateItemNames()
-except ValidationError as e: validation_errors.append(e)
-
-try: DataValidation.checkForDuplicateLocationNames()
-except ValidationError as e: validation_errors.append(e)
-
-try: DataValidation.checkForDuplicateRegionNames()
-except ValidationError as e: validation_errors.append(e)
-
-# check that starting items are actually valid starting item definitions
-try: DataValidation.checkStartingItemsForBadSyntax()
-except ValidationError as e: validation_errors.append(e)
-
-# check that starting items and starting item categories actually exist in the items json
-try: DataValidation.checkStartingItemsForValidItemsAndCategories()
-except ValidationError as e: validation_errors.append(e)
-
-# check that placed items are actually valid place item definitions
-try: DataValidation.checkPlacedItemsAndCategoriesForBadSyntax()
-except ValidationError as e: validation_errors.append(e)
-
-# check placed item and item categories for valid options for each
-try: DataValidation.checkPlacedItemsForValidItems()
-except ValidationError as e: validation_errors.append(e)
-
-try: DataValidation.checkPlacedItemCategoriesForValidItemCategories()
-except ValidationError as e: validation_errors.append(e)
-
-# check that the game's default filler item name doesn't match an item name that they defined in their items
-try: DataValidation.checkForGameFillerMatchingAnItemName()
-except ValidationError as e: validation_errors.append(e)
-
-# check for regions that are set as non-starting regions and have no connectors to them (so are unreachable)
-try: DataValidation.checkForNonStartingRegionsThatAreUnreachable()
-except ValidationError as e: validation_errors.append(e)
-
 
 ############
 # If there are any validation errors, display all of them at once

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -40,9 +40,9 @@ location_table.append({
     # "category": custom_victory_location["category"] if "category" in custom_victory_location else []
 })
 
-location_id_to_name = {}
-location_name_to_location = {}
-location_name_groups = {}
+location_id_to_name: dict[int, str] = {}
+location_name_to_location: dict[str, dict] = {}
+location_name_groups: dict[str, list[str]] = {}
 
 for item in location_table:
     location_id_to_name[item["id"]] = item["name"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -312,9 +312,8 @@ class ManualWorld(World):
         with open(os.path.join(output_directory, filename), 'wb') as f:
             f.write(b64encode(bytes(json.dumps(data), 'utf-8')))
 
-    @classmethod
-    def stage_write_spoiler(cls, multiworld, spoiler_handle):
-        before_write_spoiler(self, multiworld, spoiler_handle)
+    def write_spoiler(self, spoiler_handle):
+        before_write_spoiler(self, self.multiworld, spoiler_handle)
 
     ###
     # Non-standard AP world methods

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -313,8 +313,8 @@ class ManualWorld(World):
             f.write(b64encode(bytes(json.dumps(data), 'utf-8')))
 
     @classmethod
-    def stage_write_spoiler(cls, world, spoiler_handle):
-        before_write_spoiler(world, spoiler_handle)
+    def stage_write_spoiler(cls, multiworld, spoiler_handle):
+        before_write_spoiler(self, multiworld, spoiler_handle)
 
     ###
     # Non-standard AP world methods

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,7 +10,7 @@ from .Data import item_table, location_table, region_table, category_table
 from .Game import game_name, filler_item_name, starting_items
 from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups
 from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups
-from .DataValidation import DataValidation, ValidationError
+from .DataValidation import runGenerationDataValidation
 
 from .Regions import create_regions
 from .Items import ManualItem
@@ -79,69 +79,7 @@ class ManualWorld(World):
 
     @classmethod
     def stage_assert_generate(cls, multiworld) -> None:
-        validation_errors = []
-
-        # check that requires have correct item names in locations and regions
-        try: DataValidation.checkItemNamesInLocationRequires()
-        except ValidationError as e: validation_errors.append(e)
-
-        try: DataValidation.checkItemNamesInRegionRequires()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check that region names are correct in locations
-        try: DataValidation.checkRegionNamesInLocations()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check that items that are required by locations and regions are also marked required
-        try: DataValidation.checkItemsThatShouldBeRequired()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check that regions that are connected to are correct
-        try: DataValidation.checkRegionsConnectingToOtherRegions()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check that the apworld creator didn't specify multiple victory conditions
-        try: DataValidation.checkForMultipleVictoryLocations()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check for duplicate names in items, locations, and regions
-        try: DataValidation.checkForDuplicateItemNames()
-        except ValidationError as e: validation_errors.append(e)
-
-        try: DataValidation.checkForDuplicateLocationNames()
-        except ValidationError as e: validation_errors.append(e)
-
-        try: DataValidation.checkForDuplicateRegionNames()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check that starting items are actually valid starting item definitions
-        try: DataValidation.checkStartingItemsForBadSyntax()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check that starting items and starting item categories actually exist in the items json
-        try: DataValidation.checkStartingItemsForValidItemsAndCategories()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check that placed items are actually valid place item definitions
-        try: DataValidation.checkPlacedItemsAndCategoriesForBadSyntax()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check placed item and item categories for valid options for each
-        try: DataValidation.checkPlacedItemsForValidItems()
-        except ValidationError as e: validation_errors.append(e)
-
-        try: DataValidation.checkPlacedItemCategoriesForValidItemCategories()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check that the game's default filler item name doesn't match an item name that they defined in their items
-        try: DataValidation.checkForGameFillerMatchingAnItemName()
-        except ValidationError as e: validation_errors.append(e)
-
-        # check for regions that are set as non-starting regions and have no connectors to them (so are unreachable)
-        try: DataValidation.checkForNonStartingRegionsThatAreUnreachable()
-        except ValidationError as e: validation_errors.append(e)
-        if len(validation_errors) > 0:
-            raise Exception("\nValidationError(s): \n\n%s\n\n" % ("\n".join([' - ' + str(validation_error) for validation_error in validation_errors])))
+        runGenerationDataValidation()
 
 
     def create_regions(self):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -27,7 +27,7 @@ from .hooks.World import \
     before_create_item, after_create_item, \
     before_set_rules, after_set_rules, \
     before_generate_basic, after_generate_basic, \
-    before_fill_slot_data, after_fill_slot_data
+    before_fill_slot_data, after_fill_slot_data, before_write_spoiler
 from .hooks.Data import hook_interpret_slot_data
 
 
@@ -373,6 +373,10 @@ class ManualWorld(World):
         filename = f"{self.multiworld.get_out_file_name_base(self.player)}.apmanual"
         with open(os.path.join(output_directory, filename), 'wb') as f:
             f.write(b64encode(bytes(json.dumps(data), 'utf-8')))
+
+    @classmethod
+    def stage_write_spoiler(cls, world, spoiler_handle):
+        before_write_spoiler(world, spoiler_handle)
 
     ###
     # Non-standard AP world methods

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,6 +10,7 @@ from .Data import item_table, location_table, region_table, category_table
 from .Game import game_name, filler_item_name, starting_items
 from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups
 from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups
+from .DataValidation import DataValidation, ValidationError
 
 from .Regions import create_regions
 from .Items import ManualItem
@@ -75,6 +76,73 @@ class ManualWorld(World):
     def interpret_slot_data(self, slot_data: dict[str, any]):
         #this is called by tools like UT
         hook_interpret_slot_data(self, self.player, slot_data)
+
+    @classmethod
+    def stage_assert_generate(cls, multiworld) -> None:
+        validation_errors = []
+
+        # check that requires have correct item names in locations and regions
+        try: DataValidation.checkItemNamesInLocationRequires()
+        except ValidationError as e: validation_errors.append(e)
+
+        try: DataValidation.checkItemNamesInRegionRequires()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check that region names are correct in locations
+        try: DataValidation.checkRegionNamesInLocations()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check that items that are required by locations and regions are also marked required
+        try: DataValidation.checkItemsThatShouldBeRequired()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check that regions that are connected to are correct
+        try: DataValidation.checkRegionsConnectingToOtherRegions()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check that the apworld creator didn't specify multiple victory conditions
+        try: DataValidation.checkForMultipleVictoryLocations()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check for duplicate names in items, locations, and regions
+        try: DataValidation.checkForDuplicateItemNames()
+        except ValidationError as e: validation_errors.append(e)
+
+        try: DataValidation.checkForDuplicateLocationNames()
+        except ValidationError as e: validation_errors.append(e)
+
+        try: DataValidation.checkForDuplicateRegionNames()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check that starting items are actually valid starting item definitions
+        try: DataValidation.checkStartingItemsForBadSyntax()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check that starting items and starting item categories actually exist in the items json
+        try: DataValidation.checkStartingItemsForValidItemsAndCategories()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check that placed items are actually valid place item definitions
+        try: DataValidation.checkPlacedItemsAndCategoriesForBadSyntax()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check placed item and item categories for valid options for each
+        try: DataValidation.checkPlacedItemsForValidItems()
+        except ValidationError as e: validation_errors.append(e)
+
+        try: DataValidation.checkPlacedItemCategoriesForValidItemCategories()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check that the game's default filler item name doesn't match an item name that they defined in their items
+        try: DataValidation.checkForGameFillerMatchingAnItemName()
+        except ValidationError as e: validation_errors.append(e)
+
+        # check for regions that are set as non-starting regions and have no connectors to them (so are unreachable)
+        try: DataValidation.checkForNonStartingRegionsThatAreUnreachable()
+        except ValidationError as e: validation_errors.append(e)
+        if len(validation_errors) > 0:
+            raise Exception("\nValidationError(s): \n\n%s\n\n" % ("\n".join([' - ' + str(validation_error) for validation_error in validation_errors])))
+
 
     def create_regions(self):
         before_create_regions(self, self.multiworld, self.player)

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -38,9 +38,9 @@ def before_create_regions(world: World, multiworld: MultiWorld, player: int):
 def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     # Use this hook to remove locations from the world
     locationNamesToRemove = [] # List of location names
-    
+
     # Add your code here to calculate which locations to remove
-    
+
     for region in multiworld.regions:
         if region.player == player:
             for location in list(region.locations):
@@ -57,20 +57,20 @@ def before_create_items_starting(item_pool: list, world: World, multiworld: Mult
 def before_create_items_filler(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
     # Use this hook to remove items from the item pool
     itemNamesToRemove = [] # List of item names
-    
+
     # Add your code here to calculate which items to remove.
-    # 
+    #
     # Because multiple copies of an item can exist, you need to add an item name
     # to the list multiple times if you want to remove multiple copies of it.
-    
+
     for itemName in itemNamesToRemove:
         item = next(i for i in item_pool if i.name == itemName)
         item_pool.remove(item)
-    
+
     return item_pool
-    
+
     # Some other useful hook options:
-    
+
     ## Place an item at a specific location
     # location = next(l for l in multiworld.get_unfilled_locations(player=player) if l.name == "Location Name")
     # item_to_place = next(i for i in item_pool if i.name == "Item Name")
@@ -88,17 +88,17 @@ def before_set_rules(world: World, multiworld: MultiWorld, player: int):
 # Called after rules for accessing regions and locations are created, in case you want to see or modify that information.
 def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     # Use this hook to modify the access rules for a given location
-    
+
     def Example_Rule(state: CollectionState) -> bool:
-        # Calculated rules take a CollectionState object and return a boolean 
+        # Calculated rules take a CollectionState object and return a boolean
         # True if the player can access the location
         # CollectionState is defined in BaseClasses
         return True
-    
+
     ## Common functions:
     # location = world.get_location(location_name, player)
     # location.access_rule = Example_Rule
-    
+
     ## Combine rules:
     # old_rule = location.access_rule
     # location.access_rule = lambda state: old_rule(state) and Example_Rule(state)
@@ -128,3 +128,7 @@ def before_fill_slot_data(slot_data: dict, world: World, multiworld: MultiWorld,
 # This is called after slot data is set and provides the slot data at the time, in case you want to check and modify it after Manual is done with it
 def after_fill_slot_data(slot_data: dict, world: World, multiworld: MultiWorld, player: int) -> dict:
     return slot_data
+
+# This is called right at the end, in case you want to write stuff to the spoiler log
+def before_write_spoiler(world: World, spoiler_handle) -> None:
+    pass

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -130,5 +130,5 @@ def after_fill_slot_data(slot_data: dict, world: World, multiworld: MultiWorld, 
     return slot_data
 
 # This is called right at the end, in case you want to write stuff to the spoiler log
-def before_write_spoiler(world: World, spoiler_handle) -> None:
+def before_write_spoiler(world: World, multiworld: MultiWorld, spoiler_handle) -> None:
     pass


### PR DESCRIPTION
We currently run the entire test suite against every installed manual world regardless of whether they're in use.  This is bad for AP load times, even when not using Manual.

This moves the heavier stuff into the generator, so we don't run as much during Launcher startup.

It also sneaks in a couple of changes that have been sitting in my working directory for the better part of a month:
- Type hints for dictionaries in Location.py
- Hook for writing to the spoiler log