### PR TITLE
Victory overhaul

### DIFF
--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -207,13 +207,6 @@ class DataValidation():
                     raise ValidationError("Region %s connects to a region %s, which is misspelled or does not exist." % (region_name, connecting_region))
 
     @staticmethod
-    def checkForMultipleVictoryLocations():
-        victory_count = len([location["name"] for location in DataValidation.location_table if "victory" in location and location["victory"]])
-
-        if victory_count > 1:
-            raise ValidationError("There are %s victory locations defined, but there should only be 1." % (str(victory_count)))
-
-    @staticmethod
     def checkForDuplicateItemNames():
         for item in DataValidation.item_table:
             name_count = len([i for i in DataValidation.item_table if i["name"] == item["name"]])
@@ -367,10 +360,6 @@ def runGenerationDataValidation() -> None:
 
     # check that regions that are connected to are correct
     try: DataValidation.checkRegionsConnectingToOtherRegions()
-    except ValidationError as e: validation_errors.append(e)
-
-    # check that the apworld creator didn't specify multiple victory conditions
-    try: DataValidation.checkForMultipleVictoryLocations()
     except ValidationError as e: validation_errors.append(e)
 
     # check for duplicate names in items, locations, and regions

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -10,16 +10,12 @@ location_table = before_location_table_processed(location_table)
 ######################
 
 count = starting_index + 500 # 500 each for items and locations
-custom_victory_location = {}
-victory_key = None
+victory_names = []
 
 # add sequential generated ids to the lists
 for key, _ in enumerate(location_table):
     if "victory" in location_table[key] and location_table[key]["victory"]:
-        custom_victory_location = location_table[key]
-        victory_key = key # store the victory location to be removed later
-
-        continue
+        victory_names.append(location_table[key]["name"])
 
     location_table[key]["id"] = count
 
@@ -28,17 +24,16 @@ for key, _ in enumerate(location_table):
 
     count += 1
 
-if victory_key is not None:
-    location_table.pop(victory_key)
-
-# Add the game completion location, which will have the Victory item assigned to it automatically
-location_table.append({
-    "id": count + 1,
-    "name": "__Manual Game Complete__",
-    "region": custom_victory_location["region"] if "region" in custom_victory_location else "Manual",
-    "requires": custom_victory_location["requires"] if "requires" in custom_victory_location else []
-    # "category": custom_victory_location["category"] if "category" in custom_victory_location else []
-})
+if not victory_names:
+    # Add the game completion location, which will have the Victory item assigned to it automatically
+    location_table.append({
+        "id": count + 1,
+        "name": "__Manual Game Complete__",
+        "region": custom_victory_location["region"] if "region" in custom_victory_location else "Manual",
+        "requires": custom_victory_location["requires"] if "requires" in custom_victory_location else []
+        # "category": custom_victory_location["category"] if "category" in custom_victory_location else []
+    })
+    victory_names.append("__Manual Game Complete__")
 
 location_id_to_name: dict[int, str] = {}
 location_name_to_location: dict[str, dict] = {}

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -10,7 +10,7 @@ location_table = before_location_table_processed(location_table)
 ######################
 
 count = starting_index + 500 # 500 each for items and locations
-victory_names = []
+victory_names: list[str] = []
 
 # add sequential generated ids to the lists
 for key, _ in enumerate(location_table):
@@ -29,8 +29,8 @@ if not victory_names:
     location_table.append({
         "id": count + 1,
         "name": "__Manual Game Complete__",
-        "region": custom_victory_location["region"] if "region" in custom_victory_location else "Manual",
-        "requires": custom_victory_location["requires"] if "requires" in custom_victory_location else []
+        "region": "Manual",
+        "requires": []
         # "category": custom_victory_location["category"] if "category" in custom_victory_location else []
     })
     victory_names.append("__Manual Game Complete__")

--- a/src/Options.py
+++ b/src/Options.py
@@ -15,6 +15,7 @@ manual_options = before_options_defined({})
 if len(victory_names) > 1:
     goal = {'option_' + v: i for i, v in enumerate(victory_names)}
     manual_options['goal'] = type('goal', (Choice,), goal)
+    manual_options['goal'].__doc__ = "Choose your victory condition."
 
 if any(item.get('trap') for item in item_table):
     manual_options["filler_traps"] = FillerTrapPercent

--- a/src/Options.py
+++ b/src/Options.py
@@ -11,6 +11,10 @@ class FillerTrapPercent(Range):
 
 manual_options = before_options_defined({})
 
+if len(victory_names) > 1:
+    goal = {'option_' + v: i for i, v in enumerate(victory_names)}
+    manual_options['goal'] = type('goal', (Choice,), goal)
+
 manual_options["filler_traps"] = FillerTrapPercent
 
 for category in category_table:
@@ -20,10 +24,6 @@ for category in category_table:
         if option_name not in manual_options:
             manual_options[option_name] = type(option_name, (DefaultOnToggle,), {"default": True})
             manual_options[option_name].__doc__ = "Should items/locations linked to this option be enabled?"
-
-if len(victory_names) > 1:
-    goal = {'option_' + v: i for i, v in enumerate(victory_names)}
-    manual_options['goal'] = type('goal', (Choice,), goal)
 
 manual_options = after_options_defined(manual_options)
 manual_options_data = make_dataclass('ManualOptionsClass', manual_options.items(), bases=(PerGameCommonOptions,))

--- a/src/Options.py
+++ b/src/Options.py
@@ -2,6 +2,7 @@ from Options import FreeText, NumericOption, Toggle, DefaultOnToggle, Choice, Te
 from dataclasses import make_dataclass
 from .hooks.Options import before_options_defined, after_options_defined
 from .Data import category_table
+from .Locations import victory_names
 
 
 class FillerTrapPercent(Range):
@@ -19,6 +20,10 @@ for category in category_table:
         if option_name not in manual_options:
             manual_options[option_name] = type(option_name, (DefaultOnToggle,), {"default": True})
             manual_options[option_name].__doc__ = "Should items/locations linked to this option be enabled?"
+
+if len(victory_names) > 1:
+    goal = {'option_' + v: i for i, v in enumerate(victory_names)}
+    manual_options['goal'] = type('goal', (Choice,), goal)
 
 manual_options = after_options_defined(manual_options)
 manual_options_data = make_dataclass('ManualOptionsClass', manual_options.items(), bases=(PerGameCommonOptions,))

--- a/src/Options.py
+++ b/src/Options.py
@@ -3,6 +3,7 @@ from dataclasses import make_dataclass
 from .hooks.Options import before_options_defined, after_options_defined
 from .Data import category_table
 from .Locations import victory_names
+from .Items import item_table
 
 
 class FillerTrapPercent(Range):
@@ -15,7 +16,8 @@ if len(victory_names) > 1:
     goal = {'option_' + v: i for i, v in enumerate(victory_names)}
     manual_options['goal'] = type('goal', (Choice,), goal)
 
-manual_options["filler_traps"] = FillerTrapPercent
+if any(item.get('trap') for item in item_table):
+    manual_options["filler_traps"] = FillerTrapPercent
 
 for category in category_table:
     for option_name in category_table[category].get("yaml_option", []):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -90,6 +90,9 @@ class ManualWorld(World):
         location_game_complete = self.multiworld.get_location(victory_names[get_option_value(self.multiworld, self.player, 'goal')], self.player)
         location_game_complete.address = None
 
+        for unused_goal in [self.multiworld.get_location(name, self.player) for name in victory_names if name != location_game_complete.name]:
+            unused_goal.parent_region.locations.remove(unused_goal)
+
         location_game_complete.place_locked_item(
             ManualItem("__Victory__", ItemClassification.progression, None, player=self.player))
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,7 @@ from worlds.LauncherComponents import Component, SuffixIdentifier, components, T
 
 from .Data import item_table, location_table, region_table, category_table
 from .Game import game_name, filler_item_name, starting_items
-from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups
+from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups, victory_names
 from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups
 from .DataValidation import runGenerationDataValidation
 
@@ -87,7 +87,7 @@ class ManualWorld(World):
 
         create_regions(self, self.multiworld, self.player)
 
-        location_game_complete = self.multiworld.get_location("__Manual Game Complete__", self.player)
+        location_game_complete = self.multiworld.get_location(victory_names[get_option_value(self.multiworld, self.player, 'goal')], self.player)
         location_game_complete.address = None
 
         location_game_complete.place_locked_item(

--- a/src/data/locations.json
+++ b/src/data/locations.json
@@ -304,5 +304,17 @@
             "She-Hulk",
             "Taskmaster"
         ]
+    },
+    {
+        "name": "Marvel%",
+        "victory": true,
+        "category": ["All Characters Complete!"],
+        "requires": "|@Right Side:all|"
+    },
+    {
+        "name": "Capcom%",
+        "victory": true,
+        "category": ["All Characters Complete!"],
+        "requires": "|@Left Side:all|"
     }
 ]


### PR DESCRIPTION
Just a small change to the way Victory locations are handled.

We no longer need to replace the original location with `__Manual Game Complete__` (Though it remains if the creator didn't make a victory location)

Instead, we simply place `__Victory__` on the json defined location directly.  

Also, I added the ability to define multiple victory locations, and an auto-yaml option to set your goal if you do so.