### PR TITLE
Quick Fix: crash when requires function has no arguments

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -82,6 +82,8 @@ def set_rules(base: "ManualWorld", world: MultiWorld, player: int):
         for item in re.findall(r'\{(\w+)\(([^)]*)\)\}', requires_list):
             func_name = item[0]
             func_args = item[1].split(",")
+            if func_args == ['']:
+                func_args.pop()
             func = getattr(Rules, func_name)
             result = func(base, world, state, player, *func_args)
             if isinstance(result, bool):


### PR DESCRIPTION
Quick fix to remove the empty arguments of functions so the examples in hooks/rules.py actually work