### PR TITLE
Pull name_to_id mappings from the game's datapackage, rather than the combined datapackage

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -401,7 +401,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 20240128 # YYYYMMDD
+    version = 2024_03_21 # YYYYMMDD
     found = False
     for c in components:
         if c.display_name == "Manual Client":


### PR DESCRIPTION
Fixes the bug when item names overlap with other games

![image](https://github.com/ManualForArchipelago/Manual/assets/194254/a9b8da5f-5b30-48e6-89b6-24235b236550)
