### PR TITLE
Add the foundation for UT integrated hooks

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -35,7 +35,6 @@ try:
     from .hooks.World import ut_enabled
 except Exception as e:
     ut_enabled = False
-    print(e)
 
 
 class ManualWeb(WebWorld):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -31,6 +31,11 @@ from .hooks.World import \
     before_generate_basic, after_generate_basic, \
     before_fill_slot_data, after_fill_slot_data, before_write_spoiler
 from .hooks.Data import hook_interpret_slot_data
+try:
+    from .hooks.World import ut_enabled
+except Exception as e:
+    ut_enabled = False
+    print(e)
 
 
 class ManualWeb(WebWorld):
@@ -386,6 +391,15 @@ class ManualWorld(World):
             'regions': region_table,
             'categories': category_table
         }
+    
+    # for the universal tracker, doesn't get called in standard gen
+    @staticmethod
+    def return_slot_data(slot_data):
+        # returning slot_data so it regens, giving it back in multiworld.re_gen_passthrough
+        return slot_data
+    
+    if ut_enabled:
+        interpret_slot_data = return_slot_data
 
 ###
 # Non-world client methods

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -30,7 +30,6 @@ from .hooks.World import \
     before_set_rules, after_set_rules, \
     before_generate_basic, after_generate_basic, \
     before_fill_slot_data, after_fill_slot_data, before_write_spoiler
-from .hooks.Data import hook_interpret_slot_data
 try:
     from .hooks.World import ut_enabled
 except Exception as e:
@@ -79,9 +78,12 @@ class ManualWorld(World):
     location_name_to_location = location_name_to_location
     location_name_groups = location_name_groups
 
-    def interpret_slot_data(self, slot_data: dict[str, any]):
+    def return_slot_data(self, slot_data: dict[str, any]):
         #this is called by tools like UT
-        hook_interpret_slot_data(self, self.player, slot_data)
+        return slot_data
+    
+    if ut_enabled:
+        interpret_slot_data = return_slot_data
 
     @classmethod
     def stage_assert_generate(cls, multiworld) -> None:
@@ -390,15 +392,6 @@ class ManualWorld(World):
             'regions': region_table,
             'categories': category_table
         }
-    
-    # for the universal tracker, doesn't get called in standard gen
-    @staticmethod
-    def return_slot_data(slot_data):
-        # returning slot_data so it regens, giving it back in multiworld.re_gen_passthrough
-        return slot_data
-    
-    if ut_enabled:
-        interpret_slot_data = return_slot_data
 
 ###
 # Non-world client methods

--- a/src/hooks/Data.py
+++ b/src/hooks/Data.py
@@ -21,8 +21,3 @@ def after_load_region_file(region_table: dict) -> dict:
 # called after the categories.json file has been loaded
 def after_load_category_file(category_table: dict) -> dict:
     return category_table
-
-# called when an external tool (eg Univeral Tracker) ask for slot data to be read
-# use this if you want to restore more data
-def hook_interpret_slot_data(world, player: int, slot_data: dict[str, any]):
-    pass

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -29,6 +29,12 @@ from ..Helpers import is_option_enabled, get_option_value
 ########################################################################################
 
 
+# Universal Tracker Enabler:
+# Uncomment this line if you want your _hooks_ to interact with universal tracker.
+# Normal universal tracker integration will work fine, but if you are using hooks to
+# randomize the multiworld you can use this to fix how UT interacts with your world.
+
+# ut_enabled = True
 
 # Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -36,6 +36,9 @@ from ..Helpers import is_option_enabled, get_option_value
 
 # ut_enabled = True
 
+# You can see if the current generation is a universal tracker "fake" generation with:
+# if hasattr(multiworld, "re_gen_passthrough")
+
 # Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):
     pass


### PR DESCRIPTION
Adds a "hook" that can enable the universal tracker secondary generation.

Some games are using hooks to randomize the location set, and this does not interact well with how Universal Tracker shows available locations.

This foundation allows the author to know if the generation is a UT gen or not, and can modify their hooks accordingly.