### PR TITLE
add conversion of existing goal option as alias for new system

### DIFF
--- a/src/Options.py
+++ b/src/Options.py
@@ -16,12 +16,13 @@ if len(victory_names) > 1:
     goal = {'option_' + v: i for i, v in enumerate(victory_names)}
     docstring = "Choose your victory condition."
     defaultvalue = 0
-    if manual_options.get('goal'): 
-    #Grab existing Goal option and make alias out of it's values
-        for alias, value in manual_options.get('goal').options.items():
-            goal[f"alias_{alias}"] = value
-        docstring = manual_options.get('goal').__doc__
-        defaultvalue = manual_options.get('goal').default
+    # Check for existing Goal option and make alias out of it's values if possible
+    if manual_options.get('goal'):
+        if issubclass(manual_options['goal'], Choice):
+            for alias, value in manual_options['goal'].options.items():
+                goal[f"alias_{alias}"] = value
+            defaultvalue = manual_options['goal'].default
+        docstring = manual_options['goal'].__doc__ or docstring
     manual_options['goal'] = type('goal', (Choice,), goal)
     manual_options['goal'].__doc__ = docstring
     manual_options['goal'].default = defaultvalue

--- a/src/Options.py
+++ b/src/Options.py
@@ -4,6 +4,7 @@ from .hooks.Options import before_options_defined, after_options_defined
 from .Data import category_table
 from .Locations import victory_names
 from .Items import item_table
+import logging
 
 
 class FillerTrapPercent(Range):
@@ -14,18 +15,11 @@ manual_options = before_options_defined({})
 
 if len(victory_names) > 1:
     goal = {'option_' + v: i for i, v in enumerate(victory_names)}
-    docstring = "Choose your victory condition."
-    defaultvalue = 0
-    # Check for existing Goal option and make alias out of it's values if possible
+    # Check for existing Goal option
     if manual_options.get('goal'):
-        if issubclass(manual_options['goal'], Choice):
-            for alias, value in manual_options['goal'].options.items():
-                goal[f"alias_{alias}"] = value
-            defaultvalue = manual_options['goal'].default
-        docstring = manual_options['goal'].__doc__ or docstring
+        logging.warn("Existing Goal option found, it will be overwritten by Manual's generated Goal option.\nIf you want to support old yaml you will need to add alias in after_options_defined")
     manual_options['goal'] = type('goal', (Choice,), goal)
-    manual_options['goal'].__doc__ = docstring
-    manual_options['goal'].default = defaultvalue
+    manual_options['goal'].__doc__ = "Choose your victory condition."
 
 
 if any(item.get('trap') for item in item_table):

--- a/src/Options.py
+++ b/src/Options.py
@@ -14,8 +14,18 @@ manual_options = before_options_defined({})
 
 if len(victory_names) > 1:
     goal = {'option_' + v: i for i, v in enumerate(victory_names)}
+    docstring = "Choose your victory condition."
+    defaultvalue = 0
+    if manual_options.get('goal'): 
+    #Grab existing Goal option and make alias out of it's values
+        for alias, value in manual_options.get('goal').options.items():
+            goal[f"alias_{alias}"] = value
+        docstring = manual_options.get('goal').__doc__
+        defaultvalue = manual_options.get('goal').default
     manual_options['goal'] = type('goal', (Choice,), goal)
-    manual_options['goal'].__doc__ = "Choose your victory condition."
+    manual_options['goal'].__doc__ = docstring
+    manual_options['goal'].default = defaultvalue
+
 
 if any(item.get('trap') for item in item_table):
     manual_options["filler_traps"] = FillerTrapPercent

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -40,4 +40,18 @@ def before_options_defined(options: dict) -> dict:
 
 # This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options
 def after_options_defined(options: dict) -> dict:
+    # The generated goal option will not keep your defined values or documentation string you'll need to add them here:
+    # To automatically convert your own goal to alias of the generated goal uncomment the lines below and replace 'Goal' with your own option of type Choice
+
+    # your_goal_class = Goal #Your Goal class here
+    # generated_goal = options.get('goal', {})
+    # if generated_goal and issubclass(your_goal_class, Choice) and not issubclass(generated_goal, Goal):
+    #     goals = {'option_' + i: v for i, v in generated_goal.options.items() if i != 'default'}
+    #     for option, value in your_goal_class.options.items():
+    #         if option == 'default':
+    #             continue
+    #         goals[f"alias_{option}"] = value
+    #     options['goal'] = type('goal', (Choice,), goals)
+    #     options['goal'].default = your_goal_class.options.get('default', generated_goal.default)
+    #     options['goal'].__doc__ = your_goal_class.__doc__ or options['goal'].__doc__
     return options

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -45,7 +45,7 @@ def after_options_defined(options: dict) -> dict:
 
     # your_goal_class = Goal #Your Goal class here
     # generated_goal = options.get('goal', {})
-    # if generated_goal and issubclass(your_goal_class, Choice) and not issubclass(generated_goal, Goal):
+    # if generated_goal and issubclass(your_goal_class, Choice) and not issubclass(generated_goal, your_goal_class):
     #     goals = {'option_' + i: v for i, v in generated_goal.options.items() if i != 'default'}
     #     for option, value in your_goal_class.options.items():
     #         if option == 'default':


### PR DESCRIPTION
~im adding this so if someone (like me) used a goal option in the options.py hook before the overhaul it will convert the values to be alias to the new system, it will also grab the \_\_doc\_\_ string that's used to explain the options
the only down side is when they convert their victory locations in locations.json they need to be in the same order as before so the int values stay the same
As a bonus existing yaml with the goal option defined will work since it will use the alias and if you do it correctly then it uses corresponding victory in the new system
also when we add a options.json if its run before this then it should also be compatible (I might work on it soonish)~
Changed to a Warning based on feedback and added code to hook