### PR TITLE
Add $schema property to every json

### DIFF
--- a/schemas/Manual.categories.schema.json
+++ b/schemas/Manual.categories.schema.json
@@ -3,11 +3,18 @@
     "$id": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.categories.schema.json",
     "description": "Schema for ManualAP categories.json",
     "type": "object",
+    "properties": {
+        "$schema": {
+            "type":"string",
+            "description": "The schema to verify this document against."
+        }
+    },
     "patternProperties": {
-        "^.*$": {
+        "^[^$].*$": {
             "anyOf": [
                 {
                     "type": "object",
+                    "description": "Name of the category",
                     "properties": {
                         "hidden": {
                             "description": "(Optional) Should this category be Hidden in the client?",

--- a/schemas/Manual.game.schema.json
+++ b/schemas/Manual.game.schema.json
@@ -4,6 +4,10 @@
     "description": "Schema for ManualAP game.json",
     "type": "object",
     "properties": {
+        "$schema": {
+            "type":"string",
+            "description": "The schema to verify this document against."
+        },
         "game": {
             "description": "The name of your game, compatible with capital letters.",
             "type": "string"

--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -1,77 +1,89 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.items.schema.json",
-  "description": "Schema for ManualAP items.json",
-  "type": "array",
-  "items": {
-    "$ref": "#/definitions/Item"
-  },
-  "definitions": {
-    "Item": {
-      "type": "object",
-        "properties": {
-            "name": {
-                "description": "The unique name of the item. Do not use () or : in the name",
-                "type": "string"
-            },
-            "progression": {
-                "description": "(Optional) Is this item needed to unlock locations? Defaults to false if not included.",
-                "default": true,
-                "type": "boolean"
-            },
-            "count": {
-                "description": "(Optional) Number of copy of this item in the pool.",
-                "type": "integer",
-                "default": 1
-            },
-            "category": {
-                "description": "(Optional) The category(ies) this item fit in",
-                "type": "array",
-                "items": {
-                    "$ref": "#/definitions/Category"
-                },
-                "minItems": 1,
-                "uniqueItems": true
-            },
-            "useful": {
-                "description": "(Optional) Is this item usefull to have? Used for items that are not progression but you still want the rando to really use.",
-                "type": "boolean"
-            },
-            "progression_skip_balancing": {
-                "description": "(Optional) Should this item not get included in progression balance swaps. For more info check the discord",
-                "type": "boolean",
-                "default": true
-            },
-            "trap": {
-                "description": "(Optional) Is this item a trap? Something the player doesnt want to get.",
-                "type": "boolean",
-                "default": true
-            },
-            "early": {
-                "description": "(Optional) Is this item required to be placed somewhere accessible from the start (Sphere 1)",
-                "type": "boolean",
-                "default": true
-            },
-            "local": {
-                "description": "(Optional) Is this item supposed to be only in your locations(true) or anywhere(false)",
-                "type": "boolean",
-                "default": true
-            },
-            "_comment": {"$ref": "#/definitions/comment"}
-
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.items.schema.json",
+    "description": "Schema for ManualAP items.json",
+    "type": ["array", "object"],
+    "items": {
+        "$ref": "#/definitions/Item"
+    },
+    "properties": {
+        "$schema": {
+            "type":"string",
+            "description": "The schema to verify this document against."
         },
-        "required": ["name"]
+        "data": {
+            "description": "List of Items",
+            "type": "array",
+            "items": {"$ref": "#/definitions/Item"}
+        },
+        "_comment": {"$ref": "#/definitions/comment"}
     },
-    "Category": {
-        "type": "string"
-    },
-    "comment": {
-        "description": "(Optional) Does nothing, Its mainly here for Dev notes for future devs to understand your logic",
-        "type": ["string", "array"],
-        "items": {
-            "description": "A line of comment",
-            "type":"string"
+    "definitions": {
+        "Item": {
+        "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The unique name of the item. Do not use () or : in the name",
+                    "type": "string"
+                },
+                "progression": {
+                    "description": "(Optional) Is this item needed to unlock locations? Defaults to false if not included.",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "count": {
+                    "description": "(Optional) Number of copy of this item in the pool.",
+                    "type": "integer",
+                    "default": 1
+                },
+                "category": {
+                    "description": "(Optional) The category(ies) this item fit in",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Category"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "useful": {
+                    "description": "(Optional) Is this item usefull to have? Used for items that are not progression but you still want the rando to really use.",
+                    "type": "boolean"
+                },
+                "progression_skip_balancing": {
+                    "description": "(Optional) Should this item not get included in progression balance swaps. For more info check the discord",
+                    "type": "boolean",
+                    "default": true
+                },
+                "trap": {
+                    "description": "(Optional) Is this item a trap? Something the player doesnt want to get.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "early": {
+                    "description": "(Optional) Is this item required to be placed somewhere accessible from the start (Sphere 1)",
+                    "type": "boolean",
+                    "default": true
+                },
+                "local": {
+                    "description": "(Optional) Is this item supposed to be only in your locations(true) or anywhere(false)",
+                    "type": "boolean",
+                    "default": true
+                },
+                "_comment": {"$ref": "#/definitions/comment"}
+
+            },
+            "required": ["name"]
+        },
+        "Category": {
+            "type": "string"
+        },
+        "comment": {
+            "description": "(Optional) Does nothing, Its mainly here for Dev notes for future devs to understand your logic",
+            "type": ["string", "array"],
+            "items": {
+                "description": "A line of comment",
+                "type":"string"
+            }
         }
     }
-  }
 }

--- a/schemas/Manual.locations.schema.json
+++ b/schemas/Manual.locations.schema.json
@@ -2,9 +2,21 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.locations.schema.json",
     "description": "Schema for ManualAP locations.json",
-    "type": "array",
+    "type": ["array", "object"],
     "items": {
         "$ref": "#/definitions/Location"
+    },
+    "properties": {
+        "$schema": {
+            "type":"string",
+            "description": "The schema to verify this document against."
+        },
+        "data": {
+            "description": "List of locations for this apworld",
+            "type": "array",
+            "items": {"$ref": "#/definitions/Location"}
+        },
+        "_comment": {"$ref": "#/definitions/comment"}
     },
     "definitions": {
         "Location": {

--- a/schemas/Manual.meta.schema.json
+++ b/schemas/Manual.meta.schema.json
@@ -4,6 +4,10 @@
     "description": "Schema for ManualAP meta.json",
     "type": "object",
     "properties": {
+        "$schema": {
+            "type":"string",
+            "description": "The schema to verify this document against."
+        },
         "_comment": {"$ref": "#/definitions/comment"},
         "enable_region_diagram": {
             "description": "Enable the generation of puml diagram of your apworld region and locations for debug purposes",

--- a/schemas/Manual.regions.schema.json
+++ b/schemas/Manual.regions.schema.json
@@ -3,11 +3,18 @@
     "$id": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.regions.schema.json",
     "description": "Schema for ManualAP regions.json",
     "type": "object",
+    "properties": {
+        "$schema": {
+            "type":"string",
+            "description": "The schema to verify this document against."
+        }
+    },
     "patternProperties": {
-        "^.*$": {
+        "^[^$].*$": {
             "anyOf": [
                 {
                     "type": "object",
+                    "description": "Name of the region",
                     "properties": {
                         "requires": {
                             "description": "(Optional) Either an array of items or a boolean logic string(check discord).",

--- a/schemas/Manual.schema.catalog.development.json
+++ b/schemas/Manual.schema.catalog.development.json
@@ -1,42 +1,42 @@
 {
-  "$schema": "https://json.schemastore.org/schema-catalog.json",
-  "schemas": [
-    {
-        "name": "Manual items.json",
-        "description": "items.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/items.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.items.schema.json"
-    },
-    {
-        "name": "Manual game.json",
-        "description": "game.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/game.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.game.schema.json"
-    },
-    {
-        "name": "Manual locations.json",
-        "description": "locations.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/locations.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.locations.schema.json"
-    },
-    {
-        "name": "Manual regions.json",
-        "description": "regions.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/regions.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.regions.schema.json"
-    },
-    {
-        "name": "Manual categories.json",
-        "description": "categories.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/categories.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.categories.schema.json"
-    },
-    {
-        "name": "Manual meta.json",
-        "description": "meta.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/meta.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.meta.schema.json"
-    }
-  ],
-  "version": 20240406.02
+    "$schema": "https://json.schemastore.org/schema-catalog.json",
+    "schemas": [
+        {
+            "name": "Manual items.json",
+            "description": "items.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/items.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.items.schema.json"
+        },
+        {
+            "name": "Manual game.json",
+            "description": "game.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/game.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.game.schema.json"
+        },
+        {
+            "name": "Manual locations.json",
+            "description": "locations.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/locations.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.locations.schema.json"
+        },
+        {
+            "name": "Manual regions.json",
+            "description": "regions.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/regions.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.regions.schema.json"
+        },
+        {
+            "name": "Manual categories.json",
+            "description": "categories.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/categories.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.categories.schema.json"
+        },
+        {
+            "name": "Manual meta.json",
+            "description": "meta.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/meta.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/Schemas/schemas/Manual.meta.schema.json"
+        }
+    ],
+    "version": 20240429.01
 }

--- a/schemas/Manual.schema.catalog.json
+++ b/schemas/Manual.schema.catalog.json
@@ -1,42 +1,42 @@
 {
-  "$schema": "https://json.schemastore.org/schema-catalog.json",
-  "schemas": [
-    {
-        "name": "Manual items.json",
-        "description": "items.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/items.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.items.schema.json"
-    },
-    {
-        "name": "Manual game.json",
-        "description": "game.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/game.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.game.schema.json"
-    },
-    {
-        "name": "Manual locations.json",
-        "description": "locations.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/locations.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.locations.schema.json"
-    },
-    {
-        "name": "Manual regions.json",
-        "description": "regions.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/regions.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.regions.schema.json"
-    },
-    {
-        "name": "Manual categories.json",
-        "description": "categories.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/categories.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.categories.schema.json"
-    },
-    {
-        "name": "Manual meta.json",
-        "description": "meta.json schema file for the manual Archipelago Apworld",
-        "fileMatch": [ "**/manual*/data/meta.json" ],
-        "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.meta.schema.json"
-    }
-  ],
-  "version": 20240406.02
+    "$schema": "https://json.schemastore.org/schema-catalog.json",
+    "schemas": [
+        {
+            "name": "Manual items.json",
+            "description": "items.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/items.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.items.schema.json"
+        },
+        {
+            "name": "Manual game.json",
+            "description": "game.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/game.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.game.schema.json"
+        },
+        {
+            "name": "Manual locations.json",
+            "description": "locations.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/locations.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.locations.schema.json"
+        },
+        {
+            "name": "Manual regions.json",
+            "description": "regions.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/regions.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.regions.schema.json"
+        },
+        {
+            "name": "Manual categories.json",
+            "description": "categories.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/categories.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.categories.schema.json"
+        },
+        {
+            "name": "Manual meta.json",
+            "description": "meta.json schema file for the manual Archipelago Apworld",
+            "fileMatch": [ "**/manual*/data/meta.json" ],
+            "url": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.meta.schema.json"
+        }
+    ],
+    "version": 20240429.01
 }

--- a/src/Data.py
+++ b/src/Data.py
@@ -22,12 +22,21 @@ def load_data_file(*args) -> dict:
 
     return filedata
 
-game_table = load_data_file('game.json')
-item_table = load_data_file('items.json')
-location_table = load_data_file('locations.json')
-region_table = load_data_file('regions.json')
-category_table = load_data_file('categories.json') or {}
-meta_table = load_data_file('meta.json') or {}
+def convert_to_list(data, property_name: str) -> list:
+    if isinstance(data, dict):
+        data = data.get(property_name, [])
+    return data
+
+game_table = load_data_file('game.json') #dict
+item_table = convert_to_list(load_data_file('items.json'), 'data') #list
+location_table = convert_to_list(load_data_file('locations.json'), 'data') #list
+region_table = load_data_file('regions.json') #dict
+category_table = load_data_file('categories.json') or {} #dict
+meta_table = load_data_file('meta.json') or {} #dict
+
+# Removal of schemas in root of tables
+region_table.pop('$schema', '')
+category_table.pop('$schema', '')
 
 # hooks
 game_table = after_load_game_file(game_table)

--- a/src/data/categories.json
+++ b/src/data/categories.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.categories.schema.json",
     "Example Logic only category": {
         "hidden": true
     },

--- a/src/data/game.json
+++ b/src/data/game.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.game.schema.json",
     "game": "UltimateMarvelVsCapcom3",
     "creator": "ManualTeam",
 

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -1,403 +1,406 @@
-[ 
-    { 
-        "name": "Jill", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Shuma-Gorath", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Nemesis T-Type", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Firebrand", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Strider Hiryu", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Phoenix Wright", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Nova", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Ghost Rider", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Hawkeye", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Doctor Strange", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Chris", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Arthur", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Frank West", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Vergil", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Iron Fist", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Rocket Raccoon", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Captain America", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Dormammu", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Wesker", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Zero", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Ryu", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Dante", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Deadpool", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Wolverine", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Iron Man", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Doctor Doom", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Morrigan", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Tron", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Chun-Li", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Trish", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "X-23", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Storm", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Thor", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "M.O.D.O.K.", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Felicia", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Spencer", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Akuma", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Viewtiful Joe", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Spider-Man", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Sentinel", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Hulk", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Super-Skrull", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Hsien-Ko", 
-        "category": [
-            "Characters",
-            "Left Side",
-            "Trash"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Haggar", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "C. Viper", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Amaterasu", 
-        "category": [
-            "Characters",
-            "Left Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Phoenix", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Magneto", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "She-Hulk", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    },
-    { 
-        "name": "Taskmaster", 
-        "category": [
-            "Characters",
-            "Right Side"
-        ],
-        "progression": true 
-    }
-]
+{
+    "$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.items.schema.json",
+    "data": [
+        {
+            "name": "Jill",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Shuma-Gorath",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Nemesis T-Type",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Firebrand",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Strider Hiryu",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Phoenix Wright",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Nova",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Ghost Rider",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Hawkeye",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Doctor Strange",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Chris",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Arthur",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Frank West",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Vergil",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Iron Fist",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Rocket Raccoon",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Captain America",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Dormammu",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Wesker",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Zero",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Ryu",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Dante",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Deadpool",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Wolverine",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Iron Man",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Doctor Doom",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Morrigan",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Tron",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Chun-Li",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Trish",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "X-23",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Storm",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Thor",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "M.O.D.O.K.",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Felicia",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Spencer",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Akuma",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Viewtiful Joe",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Spider-Man",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Sentinel",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Hulk",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Super-Skrull",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Hsien-Ko",
+            "category": [
+                "Characters",
+                "Left Side",
+                "Trash"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Haggar",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "C. Viper",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Amaterasu",
+            "category": [
+                "Characters",
+                "Left Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Phoenix",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Magneto",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "She-Hulk",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        },
+        {
+            "name": "Taskmaster",
+            "category": [
+                "Characters",
+                "Right Side"
+            ],
+            "progression": true
+        }
+    ]
+}

--- a/src/data/locations.json
+++ b/src/data/locations.json
@@ -1,321 +1,325 @@
-[
-    { 
-        "name": "Beat the Game - Ryu", 
-        "category": ["Starter Team", "Left Side"],
-        "requires": "|Ryu|"
-    },
-    { 
-        "name": "Beat the Game - Chun-Li", 
-        "category": ["Starter Team", "Left Side"],
-        "requires": "|Chun-Li|"
-    },
-    { 
-        "name": "Beat the Game - Akuma", 
-        "category": ["Starter Team", "Left Side"],
-        "requires": "|Akuma|"
-    },
+{
+	"$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.locations.schema.json",
+    "data": [
+        {
+            "name": "Beat the Game - Ryu",
+            "category": ["Starter Team", "Left Side"],
+            "requires": "|Ryu|"
+        },
+        {
+            "name": "Beat the Game - Chun-Li",
+            "category": ["Starter Team", "Left Side"],
+            "requires": "|Chun-Li|"
+        },
+        {
+            "name": "Beat the Game - Akuma",
+            "category": ["Starter Team", "Left Side"],
+            "requires": "|Akuma|"
+        },
 
-    { 
-        "name": "Beat the Game - Jill", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Jill|"
-    },
-    { 
-        "name": "Beat the Game - Shuma-Gorath", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Shuma-Gorath|"
-    },
-    { 
-        "name": "Beat the Game - Nemesis T-Type", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Nemesis T-Type|"
-    },
-    { 
-        "name": "Beat the Game - Firebrand", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Firebrand|"
-    },
-    { 
-        "name": "Beat the Game - Strider Hiryu", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Strider Hiryu|"
-    },
-    { 
-        "name": "Beat the Game - Phoenix Wright", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Phoenix Wright|"
-    },
-    { 
-        "name": "Beat the Game - Nova", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Nova|"
-    },
-    { 
-        "name": "Beat the Game - Ghost Rider", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Ghost Rider|"
-    },
-    { 
-        "name": "Beat the Game - Hawkeye", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Hawkeye|"
-    },
-    { 
-        "name": "Beat the Game - Doctor Strange", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Doctor Strange|"
-    },
-    { 
-        "name": "Beat the Game - Chris", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Chris|"
-    },
-    { 
-        "name": "Beat the Game - Arthur", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Arthur|"
-    },
-    { 
-        "name": "Beat the Game - Frank West", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Frank West|"
-    },
-    { 
-        "name": "Beat the Game - Vergil", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Vergil|"
-    },
-    { 
-        "name": "Beat the Game - Iron Fist", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Iron Fist|"
-    },
-    { 
-        "name": "Beat the Game - Rocket Raccoon", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Rocket Raccoon|"
-    },
-    { 
-        "name": "Beat the Game - Captain America", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Captain America|"
-    },
-    { 
-        "name": "Beat the Game - Dormammu", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Dormammu|"
-    },
-    { 
-        "name": "Beat the Game - Wesker", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Wesker|"
-    },
-    { 
-        "name": "Beat the Game - Zero", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Zero|"
-    },
-    { 
-        "name": "Beat the Game - Dante", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Dante|"
-    },
-    { 
-        "name": "Beat the Game - Deadpool", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Deadpool|"
-    },
-    { 
-        "name": "Beat the Game - Wolverine", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Wolverine|"
-    },
-    { 
-        "name": "Beat the Game - Iron Man", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Iron Man|"
-    },
-    { 
-        "name": "Beat the Game - Doctor Doom", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Doctor Doom|"
-    },
-    { 
-        "name": "Beat the Game - Morrigan", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Morrigan|"
-    },
-    { 
-        "name": "Beat the Game - Tron", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Tron|"
-    },
-    { 
-        "name": "Beat the Game - Trish", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Trish|"
-    },
-    { 
-        "name": "Beat the Game - X-23", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|X-23|"
-    },
-    { 
-        "name": "Beat the Game - Storm", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Storm|"
-    },
-    { 
-        "name": "Beat the Game - Thor", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Thor|"
-    },
-    { 
-        "name": "Beat the Game - M.O.D.O.K.", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|M.O.D.O.K.|"
-    },
-    { 
-        "name": "Beat the Game - Felicia", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Felicia|"
-    },
-    { 
-        "name": "Beat the Game - Spencer", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Spencer|"
-    },
-    { 
-        "name": "Beat the Game - Viewtiful Joe", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Viewtiful Joe|"
-    },
-    { 
-        "name": "Beat the Game - Spider-Man", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Spider-Man|",
-        "prehint": true
-    },
-    { 
-        "name": "Beat the Game - Sentinel", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Sentinel|"
-    },
-    { 
-        "name": "Beat the Game - Hulk", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Hulk|"
-    },
-    { 
-        "name": "Beat the Game - Super-Skrull", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Super-Skrull|"
-    },
-    { 
-        "name": "Beat the Game - Hsien-Ko", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Hsien-Ko|"
-    },
-    { 
-        "name": "Beat the Game - Haggar", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Haggar|"
-    },
-    { 
-        "name": "Beat the Game - C. Viper", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|C. Viper|"
-    },
-    { 
-        "name": "Beat the Game - Amaterasu", 
-        "category": ["Unlocked Teams", "Left Side"],
-        "requires": "|Amaterasu|"
-    },
-    { 
-        "name": "Beat the Game - Phoenix", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Phoenix|"
-    },
-    { 
-        "name": "Beat the Game - Magneto", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Magneto|"
-    },
-    { 
-        "name": "Beat the Game - She-Hulk", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|She-Hulk|"
-    },
-    { 
-        "name": "Beat the Game - Taskmaster", 
-        "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Taskmaster|"
-    },
+        {
+            "name": "Beat the Game - Jill",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Jill|"
+        },
+        {
+            "name": "Beat the Game - Shuma-Gorath",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Shuma-Gorath|"
+        },
+        {
+            "name": "Beat the Game - Nemesis T-Type",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Nemesis T-Type|"
+        },
+        {
+            "name": "Beat the Game - Firebrand",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Firebrand|"
+        },
+        {
+            "name": "Beat the Game - Strider Hiryu",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Strider Hiryu|"
+        },
+        {
+            "name": "Beat the Game - Phoenix Wright",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Phoenix Wright|"
+        },
+        {
+            "name": "Beat the Game - Nova",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Nova|"
+        },
+        {
+            "name": "Beat the Game - Ghost Rider",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Ghost Rider|"
+        },
+        {
+            "name": "Beat the Game - Hawkeye",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Hawkeye|"
+        },
+        {
+            "name": "Beat the Game - Doctor Strange",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Doctor Strange|"
+        },
+        {
+            "name": "Beat the Game - Chris",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Chris|"
+        },
+        {
+            "name": "Beat the Game - Arthur",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Arthur|"
+        },
+        {
+            "name": "Beat the Game - Frank West",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Frank West|"
+        },
+        {
+            "name": "Beat the Game - Vergil",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Vergil|"
+        },
+        {
+            "name": "Beat the Game - Iron Fist",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Iron Fist|"
+        },
+        {
+            "name": "Beat the Game - Rocket Raccoon",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Rocket Raccoon|"
+        },
+        {
+            "name": "Beat the Game - Captain America",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Captain America|"
+        },
+        {
+            "name": "Beat the Game - Dormammu",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Dormammu|"
+        },
+        {
+            "name": "Beat the Game - Wesker",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Wesker|"
+        },
+        {
+            "name": "Beat the Game - Zero",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Zero|"
+        },
+        {
+            "name": "Beat the Game - Dante",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Dante|"
+        },
+        {
+            "name": "Beat the Game - Deadpool",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Deadpool|"
+        },
+        {
+            "name": "Beat the Game - Wolverine",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Wolverine|"
+        },
+        {
+            "name": "Beat the Game - Iron Man",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Iron Man|"
+        },
+        {
+            "name": "Beat the Game - Doctor Doom",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Doctor Doom|"
+        },
+        {
+            "name": "Beat the Game - Morrigan",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Morrigan|"
+        },
+        {
+            "name": "Beat the Game - Tron",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Tron|"
+        },
+        {
+            "name": "Beat the Game - Trish",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Trish|"
+        },
+        {
+            "name": "Beat the Game - X-23",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|X-23|"
+        },
+        {
+            "name": "Beat the Game - Storm",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Storm|"
+        },
+        {
+            "name": "Beat the Game - Thor",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Thor|"
+        },
+        {
+            "name": "Beat the Game - M.O.D.O.K.",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|M.O.D.O.K.|"
+        },
+        {
+            "name": "Beat the Game - Felicia",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Felicia|"
+        },
+        {
+            "name": "Beat the Game - Spencer",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Spencer|"
+        },
+        {
+            "name": "Beat the Game - Viewtiful Joe",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Viewtiful Joe|"
+        },
+        {
+            "name": "Beat the Game - Spider-Man",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Spider-Man|",
+            "prehint": true
+        },
+        {
+            "name": "Beat the Game - Sentinel",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Sentinel|"
+        },
+        {
+            "name": "Beat the Game - Hulk",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Hulk|"
+        },
+        {
+            "name": "Beat the Game - Super-Skrull",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Super-Skrull|"
+        },
+        {
+            "name": "Beat the Game - Hsien-Ko",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Hsien-Ko|"
+        },
+        {
+            "name": "Beat the Game - Haggar",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Haggar|"
+        },
+        {
+            "name": "Beat the Game - C. Viper",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|C. Viper|"
+        },
+        {
+            "name": "Beat the Game - Amaterasu",
+            "category": ["Unlocked Teams", "Left Side"],
+            "requires": "|Amaterasu|"
+        },
+        {
+            "name": "Beat the Game - Phoenix",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Phoenix|"
+        },
+        {
+            "name": "Beat the Game - Magneto",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Magneto|"
+        },
+        {
+            "name": "Beat the Game - She-Hulk",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|She-Hulk|"
+        },
+        {
+            "name": "Beat the Game - Taskmaster",
+            "category": ["Unlocked Teams", "Right Side"],
+            "requires": "|Taskmaster|"
+        },
 
-    {
-        "name": "We Saved the World!",
-        "victory": true,
-        "category": ["All Characters Complete!"],
-        "requires": [
-            "Jill",
-            "Shuma-Gorath",
-            "Nemesis T-Type",
-            "Firebrand",
-            "Strider Hiryu",
-            "Phoenix Wright",
-            "Nova",
-            "Ghost Rider",
-            "Hawkeye",
-            "Doctor Strange", 
-            "Chris",
-            "Arthur",
-            "Frank West",
-            "Vergil",
-            "Iron Fist",
-            "Rocket Raccoon",
-            "Captain America",
-            "Dormammu",
-            "Wesker",
-            "Zero",
-            "Dante",
-            "Deadpool",
-            "Wolverine",
-            "Iron Man",
-            "Doctor Doom",
-            "Morrigan",
-            "Tron",
-            "Trish",
-            "X-23",
-            "Storm",
-            "Thor",
-            "M.O.D.O.K.",
-            "Felicia",
-            "Spencer",
-            "Viewtiful Joe",
-            "Spider-Man",
-            "Sentinel",
-            "Hulk",
-            "Super-Skrull",
-            "Hsien-Ko",
-            "Haggar",
-            "C. Viper",
-            "Amaterasu",
-            "Phoenix",
-            "Magneto",
-            "She-Hulk",
-            "Taskmaster"
-        ]
-    },
-    {
-        "name": "Marvel%",
-        "victory": true,
-        "category": ["All Characters Complete!"],
-        "requires": "|@Right Side:all|"
-    },
-    {
-        "name": "Capcom%",
-        "victory": true,
-        "category": ["All Characters Complete!"],
-        "requires": "|@Left Side:all|"
-    }
-]
+        {
+            "name": "We Saved the World!",
+            "victory": true,
+            "category": ["All Characters Complete!"],
+            "requires": [
+                "Jill",
+                "Shuma-Gorath",
+                "Nemesis T-Type",
+                "Firebrand",
+                "Strider Hiryu",
+                "Phoenix Wright",
+                "Nova",
+                "Ghost Rider",
+                "Hawkeye",
+                "Doctor Strange",
+                "Chris",
+                "Arthur",
+                "Frank West",
+                "Vergil",
+                "Iron Fist",
+                "Rocket Raccoon",
+                "Captain America",
+                "Dormammu",
+                "Wesker",
+                "Zero",
+                "Dante",
+                "Deadpool",
+                "Wolverine",
+                "Iron Man",
+                "Doctor Doom",
+                "Morrigan",
+                "Tron",
+                "Trish",
+                "X-23",
+                "Storm",
+                "Thor",
+                "M.O.D.O.K.",
+                "Felicia",
+                "Spencer",
+                "Viewtiful Joe",
+                "Spider-Man",
+                "Sentinel",
+                "Hulk",
+                "Super-Skrull",
+                "Hsien-Ko",
+                "Haggar",
+                "C. Viper",
+                "Amaterasu",
+                "Phoenix",
+                "Magneto",
+                "She-Hulk",
+                "Taskmaster"
+            ]
+        },
+        {
+            "name": "Marvel%",
+            "victory": true,
+            "category": ["All Characters Complete!"],
+            "requires": "|@Right Side:all|"
+        },
+        {
+            "name": "Capcom%",
+            "victory": true,
+            "category": ["All Characters Complete!"],
+            "requires": "|@Left Side:all|"
+        }
+    ]
+}
+

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.meta.schema.json",
     "_comment": [ "remove the _ before a non-comment/info propertie to enable it",
     "For more info use json schemas to get a description and allowed value for every properties",
     "https://github.com/ManualForArchipelago/Manual/blob/main/docs/resources/json-schemas-for-world-devs.md"],

--- a/src/data/regions.json
+++ b/src/data/regions.json
@@ -1,1 +1,11 @@
-{}
+{
+    "$schema": "https://github.com/ManualForArchipelago/Manual/raw/main/schemas/Manual.regions.schema.json",
+    "ExampleRegion":{
+        "connects_to": ["Second Region"],
+        "starting": true
+    },
+    "Second Region": {
+        "requires": "|@Characters:1|",
+        "connects_to": []
+    }
+}


### PR DESCRIPTION
I went ahead and did it today,
the important code is in data.py where I added the convert_to_list function to be backward compatible with the existing code
if "data" is not the property name we want for storing the list of items/locations then that can be changed
Since this added tabulation in the locations and items jsons this pr will conflict with every other pr that modify those files
I know #46 is already adding the $schema properties in game.json but I felt it better to have it all in one pr