### PR TITLE
place_item(_category) rewrite/optimization

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -223,7 +223,7 @@ class ManualWorld(World):
                 forbidden_item_names.extend([i["name"] for i in item_name_to_item.values() if "category" in i and set(i["category"]).intersection(manual_location["dont_place_item_category"])])
 
             if forbidden_item_names:
-                forbid_items_for_player(location, forbidden_item_names, self.player)
+                forbid_items_for_player(location, set(forbidden_item_names), self.player)
                 forbidden_item_names.clear()
 
         # Handle specific item placements using fill_restrictive

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -224,7 +224,6 @@ class ManualWorld(World):
 
             if forbidden_item_names:
                 forbid_items_for_player(location, set(forbidden_item_names), self.player)
-                forbidden_item_names.clear()
 
         # Handle specific item placements using fill_restrictive
         manual_locations_with_placements = {location['name']: location for location in location_name_to_location.values() if "place_item" in location or "place_item_category" in location}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -231,14 +231,17 @@ class ManualWorld(World):
         locations_with_placements = [l for l in self.multiworld.get_unfilled_locations(player=self.player) if l.name in manual_locations_with_placements.keys()]
         for location in locations_with_placements:
             manual_location = manual_locations_with_placements[location.name]
+            eligible_items = []
             eligible_item_names = []
             forbidden_item_names = []
             place_messages = []
             forbid_messages = []
+
             #First we get possible items names
             if manual_location.get("place_item"):
                 eligible_item_names += manual_location["place_item"]
                 place_messages.append('", "'.join(manual_location["place_item"]))
+
             if manual_location.get("place_item_category"):
                 eligible_item_names += [i["name"] for i in item_name_to_item.values() if "category" in i and set(i["category"]).intersection(manual_location["place_item_category"])]
                 place_messages.append('", "'.join(manual_location["place_item_category"]) + " category(ies)")
@@ -256,7 +259,9 @@ class ManualWorld(World):
             if forbidden_item_names:
                 eligible_item_names = [name for name in eligible_item_names if name not in forbidden_item_names]
 
-            eligible_items = [item for item in self.multiworld.itempool if item.player == self.player and item.name in eligible_item_names]
+            if eligible_item_names:
+                eligible_items = [item for item in self.multiworld.itempool if item.player == self.player and item.name in eligible_item_names]
+
             if len(eligible_items) == 0:
                 nl = "\n"
                 if forbidden_item_names:


### PR DESCRIPTION
Im making this draft pr so I dont forget Im working on this.

at first I wanted to make it some place_item and place_item_category items could be combined as 1 pool of possible items to place.
currently they are mutualy exclusive, place_item_category override anything place_item add to the pool
Now with this pr both place_item and place_item_category are added together in eligible_item_names,
and then filtered using dont_place_item and dont_place_item_category the leftover eligible_item_names is then used to grab the real items
on the way there I made a dynamic error message because I now only get the real item from  eligible_item_names  once