### PR TITLE
Fix height of Game ID field using Density Independent Pixels

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -11,6 +11,7 @@ import ModuleUpdate
 ModuleUpdate.update()
 
 import Utils
+from kivy.metrics import dp
 
 if __name__ == "__main__":
     Utils.init_logging("ManualClient", exception_logger="Client")
@@ -231,12 +232,12 @@ class ManualContext(SuperContext):
             def build(self) -> Layout:
                 super().build()
 
-                self.manual_game_layout = BoxLayout(orientation="horizontal", size_hint_y=None, height=30)
+                self.manual_game_layout = BoxLayout(orientation="horizontal", size_hint_y=None, height=dp(30))
 
-                game_bar_label = Label(text="Manual Game ID", size=(150, 30), size_hint_y=None, size_hint_x=None)
+                game_bar_label = Label(text="Manual Game ID", size=(dp(150), dp(30)), size_hint_y=None, size_hint_x=None)
                 self.manual_game_layout.add_widget(game_bar_label)
                 self.game_bar_text = TextInput(text=self.ctx.suggested_game,
-                                                size_hint_y=None, height=30, multiline=False, write_tab=False)
+                                                size_hint_y=None, height=dp(30), multiline=False, write_tab=False)
                 self.manual_game_layout.add_widget(self.game_bar_text)
 
                 self.grid.add_widget(self.manual_game_layout, 3)


### PR DESCRIPTION
Use the same method as the base kvui library to properly scale the Game ID field's height based on pixel density.

Only tested on Mac (where it was an issue).

Old behavior:
<img width="413" alt="Screenshot 2024-05-24 at 12 12 08" src="https://github.com/ManualForArchipelago/Manual/assets/4594575/b1aea098-8a22-49fa-b2a2-9d4389ff3bb4">

New behavior:
<img width="410" alt="Screenshot 2024-05-24 at 12 12 22" src="https://github.com/ManualForArchipelago/Manual/assets/4594575/a5769a5e-ca9a-4291-9d76-3e55aff67f47">
