### PR TITLE
Fix multiworld.get_items() doesnt include precollected Items & ItemValue

### DIFF
--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -198,9 +198,9 @@ class DataValidation():
     @staticmethod
     def _checkLocationRequiresForItemValueWithRegex(values_requested: dict[str, int], requires) -> dict[str, int]:
         if isinstance(requires, str) and 'ItemValue' in requires:
-            for result in re.findall(r'\{ItemValue\(([^:]*)\:([^,)]+)[^)]*\)\}', requires):
+            for result in re.findall(r'\{ItemValue\(([^:]*)\:(.*?)\)\}', requires):
                 value = result[0].lower().strip()
-                count = int(result[1])
+                count = int(result[1].split(",")[0])
                 if not values_requested.get(value):
                     values_requested[value] = count
                 else:

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -198,7 +198,7 @@ class DataValidation():
     @staticmethod
     def _checkLocationRequiresForItemValueWithRegex(values_requested: dict[str, int], requires) -> dict[str, int]:
         if isinstance(requires, str) and 'ItemValue' in requires:
-            for result in re.findall(r'\{ItemValue\(([^:]*)\:([^)]+)\)\}', requires):
+            for result in re.findall(r'\{ItemValue\(([^:]*)\:([^,)]+)[^)]*\)\}', requires):
                 value = result[0].lower().strip()
                 count = int(result[1])
                 if not values_requested.get(value):
@@ -284,7 +284,6 @@ class DataValidation():
             errors = []
             existing_items = [item for item in get_items_for_player(multiworld, player) if item.code is not None and
                         item.classification == ItemClassification.progression or item.classification == ItemClassification.progression_skip_balancing]
-
             for value, val_count in values_requested.items():
                 items_value = get_items_with_value(world, multiworld, value, player, True)
                 found_count = 0

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -282,7 +282,7 @@ class DataValidation():
         # compare whats available vs requested but only if there's anything requested
         if values_requested:
             errors = []
-            existing_items = [item for item in get_items_for_player(multiworld, player) if item.code is not None and
+            existing_items = [item for item in get_items_for_player(multiworld, player, True) if item.code is not None and
                         item.classification == ItemClassification.progression or item.classification == ItemClassification.progression_skip_balancing]
             for value, val_count in values_requested.items():
                 items_value = get_items_with_value(world, multiworld, value, player, True)

--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -89,9 +89,12 @@ def _is_manualobject_enabled(multiworld: MultiWorld, player: int, object: any) -
 
     return enabled
 
-def get_items_for_player(multiworld: MultiWorld, player: int) -> List[Item]:
+def get_items_for_player(multiworld: MultiWorld, player: int, includePrecollected: bool = False) -> List[Item]:
     """Return list of items of a player including placed items"""
-    return [i for i in multiworld.get_items() if i.player == player]
+    items = [i for i in multiworld.get_items() if i.player == player]
+    if includePrecollected:
+        items.extend(multiworld.precollected_items.get(player, []))
+    return items
 
 def get_items_with_value(world: World, multiworld: MultiWorld, value: str, player: Optional[int] = None, force: bool = False) -> dict[str, int]:
     """Return a dict of every items with a specific value type present in their respective 'value' dict\n
@@ -101,7 +104,7 @@ def get_items_with_value(world: World, multiworld: MultiWorld, value: str, playe
     if player is None:
         player = world.player
 
-    player_items = get_items_for_player(multiworld, player)
+    player_items = get_items_for_player(multiworld, player, True)
     # Just a small check to prevent caching {} if items don't exist yet
     if not player_items:
         return {value: -1}

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -68,13 +68,9 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
     # this is only called when the area (think, location or region) has a "requires" field that is a string
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
-        # Generate item_counts here so it can be access each time this is called
-        if player not in world.item_counts:
-            real_pool = multiworld.get_items()
-            world.item_counts[player] = {i.name: real_pool.count(i) for i in real_pool if i.player == player}
 
         # fallback if items_counts[player] not present (will not be accurate to hooks item count)
-        items_counts = world.get_item_counts()
+        items_counts = world.get_item_counts(player)
 
         if requires_list == "":
             return True

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -79,7 +79,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
         if requires_list == "":
             return True
 
-        for item in re.findall(r'\{(\w+)\(([^)]*)\)\}', requires_list):
+        for item in re.findall(r'\{(\w+)\((.*?)\)\}', requires_list):
             func_name = item[0]
             func_args = item[1].split(",")
             if func_args == ['']:

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -69,7 +69,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
 
-        # fallback if items_counts[player] not present (will not be accurate to hooks item count)
+        # Get the "real" item counts of item in the pool/placed/starting_items
         items_counts = world.get_item_counts(player)
 
         if requires_list == "":

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,7 +19,7 @@ from .Regions import create_regions
 from .Items import ManualItem
 from .Rules import set_rules
 from .Options import manual_options_data
-from .Helpers import is_option_enabled, is_item_enabled, get_option_value
+from .Helpers import is_option_enabled, is_item_enabled, get_option_value, get_items_for_player
 
 from BaseClasses import ItemClassification, Tutorial, Item
 from Options import PerGameCommonOptions
@@ -378,9 +378,10 @@ class ManualWorld(World):
         """returns the player real item count"""
         if player is None:
             player = self.player
+
         if not self.item_counts.get(player, {}) or reset:
-            real_pool = self.multiworld.get_items()
-            self.item_counts[player] = {i.name: real_pool.count(i) for i in real_pool if i.player == player}
+            real_pool = get_items_for_player(self.multiworld, player, True)
+            self.item_counts[player] = {i.name: real_pool.count(i) for i in real_pool}
         return self.item_counts.get(player)
 
     def client_data(self):

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -23,6 +23,7 @@
             "Characters",
             "Left Side"
         ],
+        "value": {"coins": 7},
         "progression": true
     },
     {

--- a/src/data/locations.json
+++ b/src/data/locations.json
@@ -322,6 +322,6 @@
         "name": "Stars%",
         "victory": true,
         "category": ["All Characters Complete!"],
-        "requires": "{ItemValue(star:10)}"
+        "requires": "{ItemValue(star:10)} and {ItemValue(coins:10)}"
     }
 ]

--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -28,39 +28,47 @@ def requiresMelee(world: World, multiworld: MultiWorld, state: CollectionState, 
     """Returns a requires string that checks if the player has unlocked the tank."""
     return "|Figher Level:15| or |Black Belt Level:15| or |Thief Level:15|"
 
-def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, player: int, args: str):
+def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, player: int, valueCount: str, noCache: Optional[str] = None):
     """When passed a string with this format: 'valueName:int',
     this function will check if the player has collect at least 'int' valueName worth of items\n
-    eg. {ItemValue(Coins:12)} will check if the player has collect at least 12 coins worth of items
+    eg. {ItemValue(Coins:12)} will check if the player has collect at least 12 coins worth of items\n
+    You can add a second string argument to disable creating/checking the cache like this:
+    '{ItemValue(Coins:12,Disable)}' it can be any string you want
     """
 
-    args_list = args.split(":")
-    if not len(args_list) == 2 or not args_list[1].isnumeric():
-        raise Exception(f"ItemValue needs a number after : so it looks something like 'ItemValue({args_list[0]}:12)'")
-    args_list[0] = args_list[0].lower().strip()
-    args_list[1] = int(args_list[1].strip())
+    valueCount = valueCount.split(":")
+    if not len(valueCount) == 2 or not valueCount[1].isnumeric():
+        raise Exception(f"ItemValue needs a number after : so it looks something like 'ItemValue({valueCount[0]}:12)'")
+    value_name = valueCount[0].lower().strip()
+    requested_count = int(valueCount[1].strip())
 
     if not hasattr(world, 'item_values_cache'): #Cache made for optimization purposes
         world.item_values_cache = {}
 
     if not world.item_values_cache.get(player, {}):
-        world.item_values_cache[player] = {
-            'state': {},
-            'count': {},
-            }
+        world.item_values_cache[player] = {}
 
-    if (args_list[0] not in world.item_values_cache[player].get('count', {}).keys()
-            or world.item_values_cache[player].get('state') != dict(state.prog_items[player])):
+    if not noCache:
+        if not world.item_values_cache[player].get(value_name, {}):
+            world.item_values_cache[player][value_name] = {
+                'state': {},
+                'count': -1,
+                }
+
+    if (noCache or world.item_values_cache[player][value_name].get('count', -1) == -1
+            or world.item_values_cache[player][value_name].get('state') != dict(state.prog_items[player])):
         #Run First Time or if state changed since last check
-        existing_item_values = get_items_with_value(world, multiworld, args_list[0])
+        existing_item_values = get_items_with_value(world, multiworld, value_name)
         total_Count = 0
         for name, value in existing_item_values.items():
             count = state.count(name, player)
             if count > 0:
                 total_Count += count * value
-        world.item_values_cache[player]['count'][args_list[0]] = total_Count
-        world.item_values_cache[player]['state'] = dict(state.prog_items[player]) #save the current gotten items to check later if its the same
-    return world.item_values_cache[player]['count'][args_list[0]] >= args_list[1]
+        if noCache:
+            return total_Count >= requested_count
+        world.item_values_cache[player][value_name]['count'] = total_Count
+        world.item_values_cache[player][value_name]['state'] = dict(state.prog_items[player]) #save the current gotten items to check later if its the same
+    return world.item_values_cache[player][value_name]['count'] >= requested_count
 
 
 # Two useful functions to make require work if an item is disabled instead of making it inaccessible

--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -57,7 +57,7 @@ def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, play
 
     if (noCache or world.item_values_cache[player][value_name].get('count', -1) == -1
             or world.item_values_cache[player][value_name].get('state') != dict(state.prog_items[player])):
-        #Run First Time or if state changed since last check
+        # Run First Time, if state changed since last check or if noCache has a value
         existing_item_values = get_items_with_value(world, multiworld, value_name)
         total_Count = 0
         for name, value in existing_item_values.items():
@@ -67,7 +67,7 @@ def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, play
         if noCache:
             return total_Count >= requested_count
         world.item_values_cache[player][value_name]['count'] = total_Count
-        world.item_values_cache[player][value_name]['state'] = dict(state.prog_items[player]) #save the current gotten items to check later if its the same
+        world.item_values_cache[player][value_name]['state'] = dict(state.prog_items[player])
     return world.item_values_cache[player][value_name]['count'] >= requested_count
 
 

--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -28,7 +28,7 @@ def requiresMelee(world: World, multiworld: MultiWorld, state: CollectionState, 
     """Returns a requires string that checks if the player has unlocked the tank."""
     return "|Figher Level:15| or |Black Belt Level:15| or |Thief Level:15|"
 
-def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, player: int, valueCount: str, noCache: Optional[str] = None):
+def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, player: int, valueCount: str, skipCache: bool = False):
     """When passed a string with this format: 'valueName:int',
     this function will check if the player has collect at least 'int' valueName worth of items\n
     eg. {ItemValue(Coins:12)} will check if the player has collect at least 12 coins worth of items\n
@@ -48,23 +48,23 @@ def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, play
     if not world.item_values_cache.get(player, {}):
         world.item_values_cache[player] = {}
 
-    if not noCache:
+    if not skipCache:
         if not world.item_values_cache[player].get(value_name, {}):
             world.item_values_cache[player][value_name] = {
                 'state': {},
                 'count': -1,
                 }
 
-    if (noCache or world.item_values_cache[player][value_name].get('count', -1) == -1
+    if (skipCache or world.item_values_cache[player][value_name].get('count', -1) == -1
             or world.item_values_cache[player][value_name].get('state') != dict(state.prog_items[player])):
-        # Run First Time, if state changed since last check or if noCache has a value
+        # Run First Time, if state changed since last check or if skipCache has a value
         existing_item_values = get_items_with_value(world, multiworld, value_name)
         total_Count = 0
         for name, value in existing_item_values.items():
             count = state.count(name, player)
             if count > 0:
                 total_Count += count * value
-        if noCache:
+        if skipCache:
             return total_Count >= requested_count
         world.item_values_cache[player][value_name]['count'] = total_Count
         world.item_values_cache[player][value_name]['state'] = dict(state.prog_items[player])


### PR DESCRIPTION
Original Title: Fix ItemValue cache breaks if used multiple times in a single requirement
~~based on this issue:
[on discord](https://discord.com/channels/1097532591650910289/1249649852372095048)
Seems I forgot to test ItemValue when its called for multiple time in the same requires and/or with multiple value types
While I made this I discovered that multiworld.get_items() does NOT return precollected items thus breaking ItemValue even more
this probably also break item_counts. (fix included)~~
# TLDR
while fixing [this issue on discord](https://discord.com/channels/1097532591650910289/1249649852372095048) I discovered that precollected items are not returned in multiworld.get_items() when ItemValue's validation sometime failed using the Manual_UltimateMarvelVsCapcom3_ManualTeam starting_items.
I realised this also affected item_counts.
oh, Also when I made ItemValue originally I forgot to test using multiple value types at the same time... but that became the secondary objective of this pr...
# What This PR Actually changes
- Make the requires function detection allow `)` in the arguments using a non-greedy/lazy regex
  - Will only break if exactly `)}` is in the function arguments
- Added the `includePrecollected: bool` param to get_items_for_player
  - With this enabled get_items_for_player include precollected items in the list
  -  Before this there was a logic bug with using starting_items and anything that uses the item_counts
- Made ItemValue actually work with multiple Value types
- Changed ItemValue's validation regex to also not be greedy/lazy
- Added a `skipCache: bool` Param for ItemValue 