### PR TITLE
Client: Hinted locations without a category key will error

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -307,6 +307,7 @@ class ManualContext(SuperContext):
                     if hint["finding_player"] == self.ctx.slot:
                         if hint["location"] in self.ctx.missing_locations:
                             location = self.ctx.get_location_by_id(hint["location"])
+                            location["category"] = location.get("category", [])
                             if "(Hinted)" not in location["category"]:
                                 location["category"].append("(Hinted)")
                                 rebuild = True


### PR DESCRIPTION
This was noticed with a very old apworld that likely predated the addition of categories to Manual. The part of the client that displays hinted locations doesn't check for the "category" key to be on the location before checking it / appending to it.

So this PR sets the location "category" to an empty list if not present.