### PR TITLE
Add canReachLocation

### DIFF
--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -128,3 +128,10 @@ def OptAll(world: World, multiworld: MultiWorld, state: CollectionState, player:
     for function in functions:
         requires_list = requires_list.replace("{" + function + "(temp)}", "{" + func_name + "(" + functions[func_name] + ")}")
     return requires_list
+
+# Rule to expose the can_reach_location core function
+def canReachLocation(world: World, multiworld: MultiWorld, state: CollectionState, player: int, location: str):
+    """Can the player reach the given location?"""
+    if state.can_reach_location(location, player):
+        return True
+    return False


### PR DESCRIPTION
Adds a new canReachLocation available rule, to expose the core `can_reach_location` function of the CollectionState. This is a commonly requested feature and could stand-in for events for logic building without requiring a bunch of extra clicks.