### PR TITLE
Don't crash if a meta.json isn't provided

### DIFF
--- a/src/Meta.py
+++ b/src/Meta.py
@@ -20,6 +20,9 @@ class ManualWeb(WebWorld):
 # Convert meta.json data to properties
 ######################################
 def set_world_description(base_doc: str) -> str:
+    if meta_table.get("docs", {}).get("apworld_description", None) is None:
+        return base_doc
+
     if isinstance(meta_table["docs"]["apworld_description"], str):
         base_doc = meta_table["docs"]["apworld_description"]
     else:


### PR DESCRIPTION
If Meta.json is missing or empty, set_world_description throws a KeyError, and prevents the world from loading.

This makes it fail gracefully.