### PR TITLE
Add local_early option and allow some copy of an item to be early

### DIFF
--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -1,91 +1,96 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.items.schema.json",
-  "description": "Schema for ManualAP items.json",
-  "type": "array",
-  "items": {
-    "$ref": "#/definitions/Item"
-  },
-  "definitions": {
-    "Item": {
-      "type": "object",
-        "properties": {
-            "name": {
-                "description": "The unique name of the item. Do not use () or : in the name",
-                "type": "string"
-            },
-            "progression": {
-                "description": "(Optional) Is this item needed to unlock locations? Defaults to false if not included.",
-                "default": true,
-                "type": "boolean"
-            },
-            "count": {
-                "description": "(Optional) Number of copy of this item in the pool.",
-                "type": "integer",
-                "default": 1
-            },
-            "category": {
-                "description": "(Optional) The category(ies) this item fit in",
-                "type": "array",
-                "items": {
-                    "$ref": "#/definitions/Category"
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/ManualForArchipelago/Manual/main/schemas/Manual.items.schema.json",
+    "description": "Schema for ManualAP items.json",
+    "type": "array",
+    "items": {
+        "$ref": "#/definitions/Item"
+    },
+    "definitions": {
+        "Item": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The unique name of the item. Do not use () or : in the name",
+                    "type": "string"
                 },
-                "minItems": 1,
-                "uniqueItems": true
-            },
-            "useful": {
-                "description": "(Optional) Is this item usefull to have? Used for items that are not progression but you still want the rando to really use.",
-                "type": "boolean"
-            },
-            "progression_skip_balancing": {
-                "description": "(Optional) Should this item not get included in progression balance swaps. For more info check the discord",
-                "type": "boolean",
-                "default": true
-            },
-            "trap": {
-                "description": "(Optional) Is this item a trap? Something the player doesnt want to get.",
-                "type": "boolean",
-                "default": true
-            },
-            "early": {
-                "description": "(Optional) Is this item required to be placed somewhere accessible from the start (Sphere 1)",
-                "type": "boolean",
-                "default": true
-            },
-            "local": {
-                "description": "(Optional) Is this item supposed to be only in your locations(true) or anywhere(false)",
-                "type": "boolean",
-                "default": true
-            },
-            "value": {
-                "description": "(Optional) A dictonary of values this item has in the format {\"name\": int,\"otherName\": int} \nUsed with the {ItemValue(Name: int)} in location requires \neg. \"value\": {\"coins\":10} mean this item is worth 10 coins",
-                "type": "object",
-                "patternProperties": {
-                    "^.+$": {
-                        "anyOf": [
-                            {
-                                "type": "integer",
-                                "description": "A value that this item has must be 'name':integer \neg. \"coins\": 10"
-                            }
-                        ]
+                "progression": {
+                    "description": "(Optional) Is this item needed to unlock locations? Defaults to false if not included.",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "count": {
+                    "description": "(Optional) Number of copy of this item in the pool.",
+                    "type": "integer",
+                    "default": 1
+                },
+                "category": {
+                    "description": "(Optional) The category(ies) this item fit in",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Category"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "useful": {
+                    "description": "(Optional) Is this item usefull to have? Used for items that are not progression but you still want the rando to really use.",
+                    "type": "boolean"
+                },
+                "progression_skip_balancing": {
+                    "description": "(Optional) Should this item not get included in progression balance swaps. For more info check the discord",
+                    "type": "boolean",
+                    "default": true
+                },
+                "trap": {
+                    "description": "(Optional) Is this item a trap? Something the player doesnt want to get.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "early": {
+                    "description": "(Optional) How many copies of this item are required to be placed somewhere accessible from the start (Sphere 1) \nChoosing 'True' mark all of them to be early",
+                    "type": ["boolean", "integer"],
+                    "default": 1
+                },
+                "local": {
+                    "description": "(Optional) Are all copies of this item supposed to be only in your locations(true) or anywhere(false)",
+                    "type": "boolean",
+                    "default": true
+                },
+                "local_early": {
+                    "description": "(Optional) How many copies of this item are supposed to be early and only in your locations. \nTrue mark all of them to be local_early. \nCan be used to mark some of the copies of an item to be early and local since 'local' is a toggle between none or all of them.",
+                    "type": ["boolean", "integer"],
+                    "default": 1
+                },
+                "value": {
+                    "description": "(Optional) A dictionary of values this item has in the format {\"name\": int,\"otherName\": int} \nUsed with the {ItemValue(Name: int)} in location requires \neg. \"value\": {\"coins\":10} mean this item is worth 10 coins",
+                    "type": "object",
+                    "patternProperties": {
+                        "^.+$": {
+                            "anyOf": [
+                                {
+                                    "type": "integer",
+                                    "description": "A value that this item has must be 'name':integer \neg. \"coins\": 10"
+                                }
+                            ]
+                        }
                     }
-                }
-            },
-            "_comment": {"$ref": "#/definitions/comment"}
+                },
+                "_comment": {"$ref": "#/definitions/comment"}
 
+            },
+            "required": ["name"]
         },
-        "required": ["name"]
-    },
-    "Category": {
-        "type": "string"
-    },
-    "comment": {
-        "description": "(Optional) Does nothing, Its mainly here for Dev notes for future devs to understand your logic",
-        "type": ["string", "array"],
-        "items": {
-            "description": "A line of comment",
-            "type":"string"
+        "Category": {
+            "type": "string"
+        },
+        "comment": {
+            "description": "(Optional) Does nothing, Its mainly here for Dev notes for future devs to understand your logic",
+            "type": ["string", "array"],
+            "items": {
+                "description": "A line of comment",
+                "type": "string"
+            }
         }
     }
-  }
 }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -117,15 +117,34 @@ class ManualWorld(World):
 
             if item_count == 0: continue
 
-            for i in range(item_count):
+            for _ in range(item_count):
                 new_item = self.create_item(name)
                 pool.append(new_item)
 
-            if item.get("early"): # only early
-                self.multiworld.early_items[self.player][name] = item_count
-            if item.get("local"): # only local
+            if item.get("early"): # Some or all early
+                if isinstance(item["early"],int) or (isinstance(item["early"],str) and item["early"].isnumeric()):
+                    self.multiworld.early_items[self.player][name] = int(item.get("early"))
+
+                elif isinstance(item["early"],bool): #No need to deal with true vs false since false wont get here
+                    self.multiworld.early_items[self.player][name] = item_count
+
+                else:
+                    raise Exception(f"Item {name}'s 'early' has an invalid value of '{item["early"]}'. \nA boolean or an integer was expected.")
+
+            if item.get("local"): # All local
                 if name not in self.multiworld.local_items[self.player].value:
                     self.options.local_items.value.add(name)
+
+            if item.get("local_early"): # Some or all local and early
+                if isinstance(item["local_early"],int) or (isinstance(item["local_early"],str) and item["local_early"].isnumeric()):
+                    self.multiworld.local_early_items[self.player][name] = int(item.get("local_early"))
+
+                elif isinstance(item["local_early"],bool):
+                    self.multiworld.local_early_items[self.player][name] = item_count
+
+                else:
+                    raise Exception(f"Item {name}'s 'local_early' has an invalid value of '{item["local_early"]}'. \nA boolean or an integer was expected.")
+
 
         pool = before_create_items_starting(pool, self, self.multiworld, self.player)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -123,13 +123,13 @@ class ManualWorld(World):
 
             if item.get("early"): # Some or all early
                 if isinstance(item["early"],int) or (isinstance(item["early"],str) and item["early"].isnumeric()):
-                    self.multiworld.early_items[self.player][name] = int(item.get("early"))
+                    self.multiworld.early_items[self.player][name] = int(item["early"])
 
                 elif isinstance(item["early"],bool): #No need to deal with true vs false since false wont get here
                     self.multiworld.early_items[self.player][name] = item_count
 
                 else:
-                    raise Exception(f"Item {name}'s 'early' has an invalid value of '{item["early"]}'. \nA boolean or an integer was expected.")
+                    raise Exception(f"Item {name}'s 'early' has an invalid value of '{item['early']}'. \nA boolean or an integer was expected.")
 
             if item.get("local"): # All local
                 if name not in self.multiworld.local_items[self.player].value:
@@ -137,13 +137,13 @@ class ManualWorld(World):
 
             if item.get("local_early"): # Some or all local and early
                 if isinstance(item["local_early"],int) or (isinstance(item["local_early"],str) and item["local_early"].isnumeric()):
-                    self.multiworld.local_early_items[self.player][name] = int(item.get("local_early"))
+                    self.multiworld.local_early_items[self.player][name] = int(item["local_early"])
 
                 elif isinstance(item["local_early"],bool):
                     self.multiworld.local_early_items[self.player][name] = item_count
 
                 else:
-                    raise Exception(f"Item {name}'s 'local_early' has an invalid value of '{item["local_early"]}'. \nA boolean or an integer was expected.")
+                    raise Exception(f"Item {name}'s 'local_early' has an invalid value of '{item['local_early']}'. \nA boolean or an integer was expected.")
 
 
         pool = before_create_items_starting(pool, self, self.multiworld, self.player)


### PR DESCRIPTION
A month or so ago I programed this and forgot to do anything with it.
So here's a way to only mark some copies of an item as early and/or local_early
unfortunatly 'local' is still a none or all option but thats a AP thing
probably a good idea to wait until #48 merge so I can properly add my modification to it