### PR TITLE
Fix the `get_filler_item_name` function

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -33,7 +33,7 @@ from .hooks.World import \
     before_generate_basic, after_generate_basic, \
     before_fill_slot_data, after_fill_slot_data, before_write_spoiler
 from .hooks.Data import hook_interpret_slot_data
-from .hooks.Items import hook_get_filler_item
+from .hooks.Items import hook_get_filler_item_name
 
 class ManualWorld(World):
     __doc__ = world_description
@@ -64,7 +64,7 @@ class ManualWorld(World):
     victory_names = victory_names
     
     def get_filler_item_name(self) -> str:
-        return hook_get_filler_item() or filler_item_name
+        return hook_get_filler_item_name() or filler_item_name
 
     def interpret_slot_data(self, slot_data: dict[str, any]):
         #this is called by tools like UT

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -26,14 +26,13 @@ from Options import PerGameCommonOptions
 from worlds.AutoWorld import World, WebWorld
 
 from .hooks.World import \
-    before_create_regions, after_create_regions, \
+    hook_get_filler_item_name, before_create_regions, after_create_regions, \
     before_create_items_starting, before_create_items_filler, after_create_items, \
     before_create_item, after_create_item, \
     before_set_rules, after_set_rules, \
     before_generate_basic, after_generate_basic, \
     before_fill_slot_data, after_fill_slot_data, before_write_spoiler
 from .hooks.Data import hook_interpret_slot_data
-from .hooks.Items import hook_get_filler_item_name
 
 class ManualWorld(World):
     __doc__ = world_description

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -28,11 +28,12 @@ from worlds.AutoWorld import World, WebWorld
 from .hooks.World import \
     before_create_regions, after_create_regions, \
     before_create_items_starting, before_create_items_filler, after_create_items, \
-    before_create_item, after_create_item, get_filler_item_name, \
+    before_create_item, after_create_item, \
     before_set_rules, after_set_rules, \
     before_generate_basic, after_generate_basic, \
     before_fill_slot_data, after_fill_slot_data, before_write_spoiler
 from .hooks.Data import hook_interpret_slot_data
+from .hooks.Items import hook_get_filler_item
 
 class ManualWorld(World):
     __doc__ = world_description
@@ -62,7 +63,8 @@ class ManualWorld(World):
     location_name_groups = location_name_groups
     victory_names = victory_names
     
-    get_filler_item_name = get_filler_item_name
+    def get_filler_item_name(self) -> str:
+        return hook_get_filler_item() or filler_item_name
 
     def interpret_slot_data(self, slot_data: dict[str, any]):
         #this is called by tools like UT

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -28,7 +28,7 @@ from worlds.AutoWorld import World, WebWorld
 from .hooks.World import \
     before_create_regions, after_create_regions, \
     before_create_items_starting, before_create_items_filler, after_create_items, \
-    before_create_item, after_create_item, \
+    before_create_item, after_create_item, get_filler_item_name, \
     before_set_rules, after_set_rules, \
     before_generate_basic, after_generate_basic, \
     before_fill_slot_data, after_fill_slot_data, before_write_spoiler
@@ -61,6 +61,8 @@ class ManualWorld(World):
     location_name_to_location = location_name_to_location
     location_name_groups = location_name_groups
     victory_names = victory_names
+    
+    get_filler_item_name = get_filler_item_name
 
     def interpret_slot_data(self, slot_data: dict[str, any]):
         #this is called by tools like UT

--- a/src/hooks/Items.py
+++ b/src/hooks/Items.py
@@ -6,5 +6,5 @@ def before_item_table_processed(item_table: list) -> list:
 
 # Use this function to change the valid filler items to be created to replace item links or starting items.
 # Default value is the 
-def hook_get_filler_item() -> str | bool:
+def hook_get_filler_item_name() -> str | bool:
     return False

--- a/src/hooks/Items.py
+++ b/src/hooks/Items.py
@@ -3,8 +3,3 @@
 # if you need access to the items after processing to add ids, etc., you should use the hooks in World.py
 def before_item_table_processed(item_table: list) -> list:
     return item_table
-
-# Use this function to change the valid filler items to be created to replace item links or starting items.
-# Default value is the `filler_item_name` from game.json
-def hook_get_filler_item_name() -> str | bool:
-    return False

--- a/src/hooks/Items.py
+++ b/src/hooks/Items.py
@@ -5,6 +5,6 @@ def before_item_table_processed(item_table: list) -> list:
     return item_table
 
 # Use this function to change the valid filler items to be created to replace item links or starting items.
-# Default value is the 
+# Default value is the `filler_item_name` from game.json
 def hook_get_filler_item_name() -> str | bool:
     return False

--- a/src/hooks/Items.py
+++ b/src/hooks/Items.py
@@ -3,3 +3,8 @@
 # if you need access to the items after processing to add ids, etc., you should use the hooks in World.py
 def before_item_table_processed(item_table: list) -> list:
     return item_table
+
+# Use this function to change the valid filler items to be created to replace item links or starting items.
+# Default value is the 
+def hook_get_filler_item() -> str | bool:
+    return False

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -115,10 +115,6 @@ def before_create_item(item_name: str, world: World, multiworld: MultiWorld, pla
 def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, player: int) -> ManualItem:
     return item
 
-# Use this function to change the valid filler items to be created to replace item links or starting items
-def get_filler_item_name() -> str:
-    return filler_item_name
-
 # This method is run towards the end of pre-generation, before the place_item options have been handled and before AP generation occurs
 def before_generate_basic(world: World, multiworld: MultiWorld, player: int) -> list:
     pass

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -5,6 +5,7 @@ from BaseClasses import MultiWorld, CollectionState
 # Object classes from Manual -- extending AP core -- representing items and locations that are used in generation
 from ..Items import ManualItem
 from ..Locations import ManualLocation
+from ..Game import filler_item_name
 
 # Raw JSON data from the Manual apworld, respectively:
 #          data/game.json, data/items.json, data/locations.json, data/regions.json
@@ -113,6 +114,10 @@ def before_create_item(item_name: str, world: World, multiworld: MultiWorld, pla
 # The item that was created is provided after creation, in case you want to modify the item
 def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, player: int) -> ManualItem:
     return item
+
+# Use this function to change the valid filler items to be created to replace item links or starting items
+def get_filler_item_name() -> str:
+    return filler_item_name
 
 # This method is run towards the end of pre-generation, before the place_item options have been handled and before AP generation occurs
 def before_generate_basic(world: World, multiworld: MultiWorld, player: int) -> list:

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -31,6 +31,11 @@ import logging
 
 
 
+# Use this function to change the valid filler items to be created to replace item links or starting items.
+# Default value is the `filler_item_name` from game.json
+def hook_get_filler_item_name() -> str | bool:
+    return False
+
 # Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):
     pass

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -5,7 +5,6 @@ from BaseClasses import MultiWorld, CollectionState
 # Object classes from Manual -- extending AP core -- representing items and locations that are used in generation
 from ..Items import ManualItem
 from ..Locations import ManualLocation
-from ..Game import filler_item_name
 
 # Raw JSON data from the Manual apworld, respectively:
 #          data/game.json, data/items.json, data/locations.json, data/regions.json


### PR DESCRIPTION
Any "item link" or "starting item from pool" references the base world function `get_filler_item_name`

By default the `get_filler_item_name` function will return a random item from the multiworld, which could break logic by adding extra progression items.

This changes that to return the normal `filler_item_name` by default, with a hook to allow the user to change the list to be anything that makes sense for that game.