### PR TITLE
Bump client version number

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -409,7 +409,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_05_05 # YYYYMMDD
+    version = 2024_07_10 # YYYYMMDD
     found = False
     for c in components:
         if c.display_name == "Manual Client":


### PR DESCRIPTION
The last couple changes to ManualClient.py weren't accompanied by a change here.  

We either need a better solution, or a CI check to stop this from being missed.