### PR TITLE
Support launching client with nogui

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -400,8 +400,13 @@ class ManualWorld(World):
 ###
 
 def launch_client(*args):
+    import CommonClient
     from .ManualClient import launch as Main
-    launch_subprocess(Main, name="Manual client")
+
+    if CommonClient.gui_enabled:
+        launch_subprocess(Main, name="Manual client")
+    else:
+        Main()
 
 class VersionedComponent(Component):
     def __init__(self, display_name: str, script_name: Optional[str] = None, func: Optional[Callable] = None, version: int = 0, file_identifier: Optional[Callable[[str], bool]] = None):


### PR DESCRIPTION
From the "send Location command for CLI" feature suggestion in Discord, specifically this message: https://discord.com/channels/1097532591650910289/1256431558387040256/1260973172052987975

The Manual client doesn't currently support launching with nogui, so this PR adds support for nogui. Support for nogui is also blocked by a bug with CommonClient in AP core, but this at least makes sure we support it when it's fixed.