### PR TITLE
Schema adjustments for defaults, structure for Builder use, etc.

### DIFF
--- a/schemas/Manual.categories.schema.json
+++ b/schemas/Manual.categories.schema.json
@@ -16,19 +16,19 @@
                     "type": "object",
                     "description": "Name of the category",
                     "properties": {
-                        "hidden": {
-                            "description": "(Optional) Should this category be Hidden in the client?",
-                            "type": "boolean",
-                            "default": true
-                        },
                         "yaml_option": {
                             "description": "(Optional) Array of Options that will decide if the items & locations in this category are enabled",
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Connects_to"
+                                "type": "string"
                             },
                             "minItems": 1,
                             "uniqueItems": true
+                        },
+                        "hidden": {
+                            "description": "(Optional) Should this category be Hidden in the client?",
+                            "type": "boolean",
+                            "default": false
                         },
                         "_comment": {"$ref": "#/definitions/comment"}
                     }
@@ -37,12 +37,6 @@
         }
     },
     "definitions": {
-        "Require": {
-            "type": ["object", "string", "array"]
-        },
-        "Connects_to": {
-            "type": "string"
-        },
         "comment": {
             "description": "(Optional) Does nothing, Its mainly here for Dev notes for future devs to understand your logic",
             "type": ["string", "array"],

--- a/schemas/Manual.game.schema.json
+++ b/schemas/Manual.game.schema.json
@@ -55,13 +55,6 @@
         "Sitems": {
             "type":"object",
             "properties": {
-                "if_previous_item":{
-                    "description": "(Optional) Causes the starting item block to only occur when any of the matching items have already been added to starting inventory by any previous starting item blocks",
-                    "type":"array",
-                    "items":{
-                        "type":"string"
-                    }
-                },
                 "items": {
                     "description": "(Optional) List of item to pick from. If not included will pick from 'item_categories' if present or from the entire item pool if absent",
                     "type":"array",
@@ -79,6 +72,13 @@
                 "random": {
                     "description": "(Optional) how many items of this block will be randomly added to inventory. Will add every item in the block if not included",
                     "type":"integer"
+                },
+                "if_previous_item":{
+                    "description": "(Optional) Causes the starting item block to only occur when any of the matching items have already been added to starting inventory by any previous starting item blocks",
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    }
                 },
                 "_comment": {"$ref": "#/definitions/comment"}
             },

--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -26,48 +26,19 @@
                     "description": "The unique name of the item. Do not use () or : in the name",
                     "type": "string"
                 },
-                "progression": {
-                    "description": "(Optional) Is this item needed to unlock locations? Defaults to false if not included.",
-                    "default": true,
-                    "type": "boolean"
+                "category": {
+                    "description": "(Optional) The category(ies) this item fit in",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
                 },
                 "count": {
                     "description": "(Optional) Number of copy of this item in the pool.",
                     "type": "integer",
                     "default": 1
-                },
-                "category": {
-                    "description": "(Optional) The category(ies) this item fit in",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Category"
-                    },
-                    "minItems": 1,
-                    "uniqueItems": true
-                },
-                "useful": {
-                    "description": "(Optional) Is this item usefull to have? Used for items that are not progression but you still want the rando to really use.",
-                    "type": "boolean"
-                },
-                "progression_skip_balancing": {
-                    "description": "(Optional) Should this item not get included in progression balance swaps. For more info check the discord",
-                    "type": "boolean",
-                    "default": true
-                },
-                "trap": {
-                    "description": "(Optional) Is this item a trap? Something the player doesnt want to get.",
-                    "type": "boolean",
-                    "default": true
-                },
-                "early": {
-                    "description": "(Optional) Is this item required to be placed somewhere accessible from the start (Sphere 1)",
-                    "type": "boolean",
-                    "default": true
-                },
-                "local": {
-                    "description": "(Optional) Is this item supposed to be only in your locations(true) or anywhere(false)",
-                    "type": "boolean",
-                    "default": true
                 },
                 "value": {
                     "description": "(Optional) A dictionary of values this item has in the format {\"name\": int,\"otherName\": int} \nUsed with the {ItemValue(Name: int)} in location requires \neg. \"value\": {\"coins\":10} mean this item is worth 10 coins",
@@ -83,13 +54,44 @@
                         }
                     }
                 },
+                "progression": {
+                    "description": "(Optional) Is this item needed to unlock locations? Defaults to false if not included.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "progression_skip_balancing": {
+                    "description": "(Optional) Should this item not get included in progression balance swaps. For more info check the discord",
+                    "type": "boolean",
+                    "default": false
+                },
+                "useful": {
+                    "description": "(Optional) Is this item usefull to have? Used for items that are not progression but you still want the rando to really use.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "trap": {
+                    "description": "(Optional) Is this item a trap? Something the player doesnt want to get.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "filler": {
+                    "description": "(Optional) Is this item a filler item? Something that is mostly useless to the player.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "early": {
+                    "description": "(Optional) Is this item required to be placed somewhere accessible from the start (Sphere 1)",
+                    "type": "boolean",
+                    "default": false
+                },
+                "local": {
+                    "description": "(Optional) Is this item supposed to be only in your locations(true) or anywhere(false)",
+                    "type": "boolean",
+                    "default": false
+                },
                 "_comment": {"$ref": "#/definitions/comment"}
-
             },
             "required": ["name"]
-        },
-        "Category": {
-            "type": "string"
         },
         "comment": {
             "description": "(Optional) Does nothing, Its mainly here for Dev notes for future devs to understand your logic",

--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -27,7 +27,7 @@
                     "type": "string"
                 },
                 "category": {
-                    "description": "(Optional) The category(ies) this item fit in",
+                    "description": "(Optional) A list of categories to be applied to this item.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -36,7 +36,7 @@
                     "uniqueItems": true
                 },
                 "count": {
-                    "description": "(Optional) Number of copy of this item in the pool.",
+                    "description": "(Optional) Total number of this item that will be in the itempool for randomization.",
                     "type": "integer",
                     "default": 1
                 },
@@ -55,27 +55,27 @@
                     }
                 },
                 "progression": {
-                    "description": "(Optional) Is this item needed to unlock locations? Defaults to false if not included.",
+                    "description": "(Optional) Is this item needed to unlock locations? For more information on item classifications, see: https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md#items",
                     "type": "boolean",
                     "default": false
                 },
                 "progression_skip_balancing": {
-                    "description": "(Optional) Should this item not get included in progression balance swaps. For more info check the discord",
+                    "description": "(Optional) Should this item not get included in progression balance swaps? For more information on item classifications, see: https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md#items",
                     "type": "boolean",
                     "default": false
                 },
                 "useful": {
-                    "description": "(Optional) Is this item usefull to have? Used for items that are not progression but you still want the rando to really use.",
+                    "description": "(Optional) Is this item useful to have but not required to complete the game? For more information on item classifications, see: https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md#items",
                     "type": "boolean",
                     "default": false
                 },
                 "trap": {
-                    "description": "(Optional) Is this item a trap? Something the player doesnt want to get.",
+                    "description": "(Optional) Is this item something the player doesn't want to get? For more information on item classifications, see: https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md#items",
                     "type": "boolean",
                     "default": false
                 },
                 "filler": {
-                    "description": "(Optional) Is this item a filler item? Something that is mostly useless to the player.",
+                    "description": "(Optional) Is this item mostly useless and okay to skip placing sometimes? For more information on item classifications, see: https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md#items",
                     "type": "boolean",
                     "default": true
                 },
@@ -90,7 +90,7 @@
                     "default": false
                 },
                 "local_early": {
-                    "description": "(Optional) How many copies of this item are supposed to be early and only in your locations. \nTrue mark all of them to be local_early. \nCan be used to mark some of the copies of an item to be early and local since 'local' is a toggle between none or all of them.",
+                    "description": "(Optional) How many copies of this item are supposed to be early and only in your locations. \nCan be used to mark some of the copies of an item to be early and local since 'local' is a toggle between none or all of them.",
                     "type": ["boolean", "integer"],
                     "default": false
                 },

--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -85,12 +85,12 @@
                     "default": false
                 },
                 "local": {
-                    "description": "(Optional) Are all copies of this item supposed to be only in your locations(true) or anywhere(false)",
+                    "description": "(Optional) Are all copies of this item supposed to be only in your locations (true), or can they be anywhere (false)?",
                     "type": "boolean",
                     "default": false
                 },
                 "local_early": {
-                    "description": "(Optional) How many copies of this item are supposed to be early and only in your locations. \nCan be used to mark some of the copies of an item to be early and local since 'local' is a toggle between none or all of them.",
+                    "description": "(Optional) How many copies of this item (or 'true' if all copies) are supposed to be early and only in your locations. \nCan be used to mark some of the copies of an item to be early and local since 'local' is a toggle between none or all of them.",
                     "type": ["boolean", "integer"],
                     "default": false
                 },

--- a/schemas/Manual.locations.schema.json
+++ b/schemas/Manual.locations.schema.json
@@ -26,15 +26,11 @@
                     "description": "The unique name of the location.",
                     "type": "string"
                 },
-                "region": {
-                    "description": "(Optional) The name of the Region this location is part of.",
-                    "type": "string"
-                },
                 "category": {
                     "description": "(Optional) An array of the Category(ies) this location is a part of.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Category"
+                        "type": "string"
                     },
                     "uniqueItems": true
                 },
@@ -46,29 +42,15 @@
                     },
                     "uniqueItems": true
                 },
-                "place_item_category": {
-                    "description": "(Optional) Specify the category of item that will be placed at this location. (Ignore Logic)",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Place_item_category"
-                    },
-                    "minItems": 0,
-                    "uniqueItems": true
+                "region": {
+                    "description": "(Optional) The name of the Region this location is part of.",
+                    "type": "string"
                 },
                 "place_item": {
                     "description": "(Optional) Specify the list of item that can be placed at this location (will only randomly choose 1).",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Place_item"
-                    },
-                    "minItems": 0,
-                    "uniqueItems": true
-                },
-                "dont_place_item_category": {
-                    "description": "(Optional) Specify the categories of items that will never be placed at this location.",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Place_item_category"
+                        "type": "string"
                     },
                     "minItems": 0,
                     "uniqueItems": true
@@ -77,24 +59,41 @@
                     "description": "(Optional) Specify the list of items that cannot be placed at this location.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Place_item"
+                        "type": "string"
+                    },
+                    "minItems": 0,
+                    "uniqueItems": true
+                },
+                "place_item_category": {
+                    "description": "(Optional) Specify the category of item that will be placed at this location. (Ignore Logic)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 0,
+                    "uniqueItems": true
+                },
+                "dont_place_item_category": {
+                    "description": "(Optional) Specify the categories of items that will never be placed at this location.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     },
                     "minItems": 0,
                     "uniqueItems": true
                 },
                 "victory": {
                     "description": "(Optional) Is this location the goal of this Manual Apworld",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false
                 },
                 "prehint": {
                     "description": "(Optional) Prehint this location.",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false
                 },
                 "_comment": {"$ref": "#/definitions/comment"}
             }
-        },
-        "Category": {
-            "type": "string"
         },
         "Require": {
             "type": ["string", "array", "object"],
@@ -109,12 +108,6 @@
                     }
                 }
             }
-        },
-        "Place_item_category": {
-            "type": "string"
-        },
-        "Place_item": {
-            "type": "string"
         },
         "comment": {
             "description": "(Optional) Does nothing, Its mainly here for Dev notes for future devs to understand your logic",

--- a/schemas/Manual.locations.schema.json
+++ b/schemas/Manual.locations.schema.json
@@ -27,7 +27,7 @@
                     "type": "string"
                 },
                 "category": {
-                    "description": "(Optional) An array of the Category(ies) this location is a part of.",
+                    "description": "(Optional) A list of categories to be applied to this location.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -35,7 +35,7 @@
                     "uniqueItems": true
                 },
                 "requires": {
-                    "description": "(Optional) Either an array of items or a boolean logic string(check discord).",
+                    "description": "(Optional) A boolean logic string that describes the required items, counts, etc. needed to reach this location.",
                     "type": [ "string", "array" ],
                     "items": {
                         "$ref": "#/definitions/Require"
@@ -43,11 +43,11 @@
                     "uniqueItems": true
                 },
                 "region": {
-                    "description": "(Optional) The name of the Region this location is part of.",
+                    "description": "(Optional) The name of the region this location is part of.",
                     "type": "string"
                 },
                 "place_item": {
-                    "description": "(Optional) Specify the list of item that can be placed at this location (will only randomly choose 1).",
+                    "description": "(Optional) Places an item that matches one of the item names listed in this setting at this location. Does not check logical access to the location.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -56,7 +56,7 @@
                     "uniqueItems": true
                 },
                 "dont_place_item": {
-                    "description": "(Optional) Specify the list of items that cannot be placed at this location.",
+                    "description": "(Optional) Places an item that DOES NOT match one of the item names listed in this setting at this location. Does not check logical access to the location.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -65,7 +65,7 @@
                     "uniqueItems": true
                 },
                 "place_item_category": {
-                    "description": "(Optional) Specify the category of item that will be placed at this location. (Ignore Logic)",
+                    "description": "(Optional) Places an item that matches at least one of the categories listed in this setting at this location. Does not check logical access to the location.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -74,7 +74,7 @@
                     "uniqueItems": true
                 },
                 "dont_place_item_category": {
-                    "description": "(Optional) Specify the categories of items that will never be placed at this location.",
+                    "description": "(Optional) Places an item that DOES NOT match at least one of the categories listed in this setting at this location. Does not check logical access to the location.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -83,12 +83,12 @@
                     "uniqueItems": true
                 },
                 "victory": {
-                    "description": "(Optional) Is this location the goal of this Manual Apworld",
+                    "description": "(Optional) Is this location one of the possible goals of this Manual APWorld?",
                     "type": "boolean",
                     "default": false
                 },
                 "prehint": {
-                    "description": "(Optional) Prehint this location.",
+                    "description": "(Optional) Should this location be hinted at the start?",
                     "type": "boolean",
                     "default": false
                 },

--- a/schemas/Manual.locations.schema.json
+++ b/schemas/Manual.locations.schema.json
@@ -56,7 +56,7 @@
                     "uniqueItems": true
                 },
                 "dont_place_item": {
-                    "description": "(Optional) Places an item that DOES NOT match one of the item names listed in this setting at this location. Does not check logical access to the location.",
+                    "description": "(Optional) Configures what item names should not end up at this location during normal generation. Does not check logical access to the location.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -74,7 +74,7 @@
                     "uniqueItems": true
                 },
                 "dont_place_item_category": {
-                    "description": "(Optional) Places an item that DOES NOT match at least one of the categories listed in this setting at this location. Does not check logical access to the location.",
+                    "description": "(Optional) Configures what item categories should not end up at this location during normal generation. Does not check logical access to the location.",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/schemas/Manual.meta.schema.json
+++ b/schemas/Manual.meta.schema.json
@@ -84,7 +84,8 @@
         },
         "enable_region_diagram": {
             "description": "Enable the generation of puml diagram of your apworld region and locations for debug purposes",
-            "type": "boolean"
+            "type": "boolean",
+            "default": false
         }
     },
     "definitions": {

--- a/schemas/Manual.meta.schema.json
+++ b/schemas/Manual.meta.schema.json
@@ -9,10 +9,6 @@
             "description": "The schema to verify this document against."
         },
         "_comment": {"$ref": "#/definitions/comment"},
-        "enable_region_diagram": {
-            "description": "Enable the generation of puml diagram of your apworld region and locations for debug purposes",
-            "type": "boolean"
-        },
         "docs": {
             "description": "Every properties linked to the documentation of your apworld",
             "type": "object",
@@ -85,6 +81,10 @@
                     }
                 }
             }
+        },
+        "enable_region_diagram": {
+            "description": "Enable the generation of puml diagram of your apworld region and locations for debug purposes",
+            "type": "boolean"
         }
     },
     "definitions": {

--- a/schemas/Manual.regions.schema.json
+++ b/schemas/Manual.regions.schema.json
@@ -17,7 +17,7 @@
                     "description": "Name of the region",
                     "properties": {
                         "requires": {
-                            "description": "(Optional) Either an array of items or a boolean logic string(check discord).",
+                            "description": "(Optional) A boolean logic string that describes the required items, counts, etc. needed to reach this region.",
                             "type": [ "string", "array" ],
                             "items": {
                                 "$ref": "#/definitions/Require"
@@ -26,7 +26,7 @@
                             "uniqueItems": true
                         },
                         "connects_to": {
-                            "description": "Array of other regions the player can go from this region.",
+                            "description": "A list of other regions that the player can reach from this region. Only describe forward connections with this setting, as backward connections are implied from regions you have already accessed.",
                             "type": "array",
                             "items": {
                                 "type": "string"
@@ -35,7 +35,7 @@
                             "uniqueItems": true
                         },
                         "starting": {
-                            "description": "(Optional) Is this region accessible from the start? Defaults to false if not included.",
+                            "description": "(Optional) Is this region accessible from the start? Or, does this region not require a connection from another region first?",
                             "type":"boolean",
                             "default": false
                         },

--- a/schemas/Manual.regions.schema.json
+++ b/schemas/Manual.regions.schema.json
@@ -29,14 +29,15 @@
                             "description": "Array of other regions the player can go from this region.",
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Connects_to"
+                                "type": "string"
                             },
                             "minItems": 0,
                             "uniqueItems": true
                         },
                         "starting": {
                             "description": "(Optional) Is this region accessible from the start? Defaults to false if not included.",
-                            "type":"boolean"
+                            "type":"boolean",
+                            "default": false
                         },
                         "_comment": {"$ref": "#/definitions/comment"}
                     }
@@ -58,9 +59,6 @@
                     }
                 }
             }
-        },
-        "Connects_to": {
-            "type": "string"
         },
         "comment": {
             "description": "(Optional) Does nothing, Its mainly here for Dev notes for future devs to understand your logic",


### PR DESCRIPTION
We were talking about default values in schema and I had some in-progress changes to schema as well, so figured I might as well do the defaults bit and get all the changes in. 😄 

The new version of the Manual Builder (WIP) heavily uses the schema files to know what the structure of objects in the JSON files should be. This will enable us to make regular updates to Manual and its structure without having to remember (in most cases) to make updates to Builder to support it as well.

Things I needed to change about the schema to support this:

- The ordering of items needed to change to an order of relative importance, so fields were moved around
- Simple collections like arrays of strings sometimes had definition entries instead of just being items: type string, and others had items: type string, so this was made consistent to the latter.
- Some typos in schema, like categories having definitions for requires/connects_to.
- Default values that represent what the value would be if the user doesn't provide one. This is helpful to Builder because it lets me display defaults if there are any, letting the user then edit them.

I think I got all the defaults, but let me know if I missed anything or mucked up anything. Not as familiar with schema things as Nico 😄 