### PR TITLE
Add Yaml Description

### DIFF
--- a/schemas/Manual.categories.schema.json
+++ b/schemas/Manual.categories.schema.json
@@ -30,6 +30,10 @@
                             "minItems": 1,
                             "uniqueItems": true
                         },
+                        "yaml_description": {
+                            "description": "(Optional) Dictionary of option-description pairs to add descriptor text to the yaml options defined in 'yaml_option'",
+                            "type": "object"
+                        }
                         "_comment": {"$ref": "#/definitions/comment"}
                     }
                 }

--- a/src/Options.py
+++ b/src/Options.py
@@ -30,6 +30,8 @@ for category in category_table:
         if option_name not in manual_options:
             manual_options[option_name] = type(option_name, (DefaultOnToggle,), {"default": True})
             manual_options[option_name].__doc__ = "Should items/locations linked to this option be enabled?"
+        if option_name in category_table[category].get("yaml_description", []):
+            manual_options[option_name].__doc__ = category_table[category]["yaml_description"][option_name]
 
 manual_options = after_options_defined(manual_options)
 manual_options_data = make_dataclass('ManualOptionsClass', manual_options.items(), bases=(PerGameCommonOptions,))

--- a/src/data/categories.json
+++ b/src/data/categories.json
@@ -4,6 +4,7 @@
         "hidden": true
     },
     "Example Yaml-option category": {
-        "yaml_option": ["DLC_enabled"]
+        "yaml_option": ["DLC_enabled"],
+        "yaml_description": {"DLC_enabled": "Include items and locations that require purchasing the DLC"}
     }
 }


### PR DESCRIPTION
Adds the optional `"yaml_description"` item to the `Categories.json` file, which allows the user to add a line of description text to the yaml options.

Example syntax:
```json
{
    "Example Yaml-option category": {
        "yaml_option": ["DLC_enabled"],
        "yaml_description": {"DLC_enabled": "Include items and locations that require purchasing the DLC"}
    }
}
```

Result in the player yaml:
```yaml
  DLC_enabled:
    # Include items and locations that require purchasing the DLC
    'false': 0
    'true': 50
```