### PR TITLE
A couple of miscellaneous fixes

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -109,7 +109,7 @@ class ManualContext(SuperContext):
         return location
 
     def get_location_by_id(self, id) -> dict[str, Any]:
-        name = self.location_names[id]
+        name = self.location_names.lookup_in_game(id)
         return self.get_location_by_name(name)
 
     def get_item_by_name(self, name):
@@ -119,7 +119,7 @@ class ManualContext(SuperContext):
         return item
 
     def get_item_by_id(self, id):
-        name = self.item_names[id]
+        name = self.item_names.lookup_in_game(id)
         return self.get_item_by_name(name)
 
     def update_ids(self, data_package) -> None:
@@ -347,7 +347,7 @@ class ManualContext(SuperContext):
 
                 for location_id in self.ctx.missing_locations:
                     # holy nesting, wow
-                    location_name = self.ctx.location_names[location_id]
+                    location_name = self.ctx.location_names.lookup_in_game(location_id)
                     location = self.ctx.get_location_by_name(location_name)
 
                     if not location:
@@ -425,7 +425,7 @@ class ManualContext(SuperContext):
                     category_scroll.add_widget(category_layout)
 
                     for location_id in self.listed_locations[location_category]:
-                        location_button = TreeViewButton(text=self.ctx.location_names[location_id], size_hint=(None, None), height=30, width=400)
+                        location_button = TreeViewButton(text=self.ctx.location_names.lookup_in_game(location_id), size_hint=(None, None), height=30, width=400)
                         location_button.bind(on_press=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
                         location_button.id = location_id
                         category_layout.add_widget(location_button)
@@ -498,7 +498,7 @@ class ManualContext(SuperContext):
 
                                 # Label (for new item listings)
                                 for network_item in self.ctx.items_received:
-                                    item_name = self.ctx.item_names[network_item.item]
+                                    item_name = self.ctx.item_names.lookup_in_game(network_item.item)
                                     item_data = self.ctx.get_item_by_name(item_name)
 
                                     if "category" not in item_data or not item_data["category"]:

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -92,7 +92,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
             if not callable(func):
                 raise ValueError(f"Invalid function `{func_name}` in {area}.")
 
-            convert_req_function_args(func, func_args, area["name"])
+            convert_req_function_args(func, func_args, area.get("name", f"An area with these parameters: {area}"))
             result = func(world, multiworld, state, player, *func_args)
             if isinstance(result, bool):
                 requires_list = requires_list.replace("{" + func_name + "(" + item[1] + ")}", "1" if result else "0")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -135,7 +135,7 @@ class ManualWorld(World):
                     raise Exception(f"Item {name}'s 'early' has an invalid value of '{item['early']}'. \nA boolean or an integer was expected.")
 
             if item.get("local"): # All local
-                if name not in self.multiworld.local_items[self.player].value:
+                if name not in self.options.local_items.value:
                     self.options.local_items.value.add(name)
 
             if item.get("local_early"): # Some or all local and early

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -61,7 +61,7 @@ class ManualWorld(World):
     location_name_to_location = location_name_to_location
     location_name_groups = location_name_groups
     victory_names = victory_names
-    
+
     def get_filler_item_name(self) -> str:
         return hook_get_filler_item_name() or filler_item_name
 
@@ -420,7 +420,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_07_17 # YYYYMMDD
+    version = 2024_08_11 # YYYYMMDD
     found = False
     for c in components:
         if c.display_name == "Manual Client":


### PR DESCRIPTION
fixes include:
1. convert_req_function_args would crash when called on a region because region don't have their `name` in the `area` object
2. usage of `self.multiworld.local_items` is deprecated (replaced with `self.options.local_items.value`)
3. calling self.location/item_names[id] in the client is deprecated since ids can now be the same for multiple games 
    - (all I did was what the deprecation message recommend aka replace the `location/item_names[id]` with  `location/item_names.lookup_in_game(id)`
    - (I might pr something later to dev choose their starting id instead of the current random ids idk)  

(I tested the client using the new lookup_in_game and it act the same as before but no deprecation warning)