### PR TITLE
Add a way to decide the initial item/location id offset 

### DIFF
--- a/schemas/Manual.game.schema.json
+++ b/schemas/Manual.game.schema.json
@@ -38,8 +38,9 @@
             "default": false
         },
         "starting_index": {
-            "description": "(Optional) (Advanced) Choose the starting index for your locations and items.\nWhen not included uses the old system to generate a unique starting index",
-            "type": "integer"
+            "description": "(Optional) (Advanced) Choose the starting index for your locations and items.",
+            "type": "integer",
+            "default": 1
         },
         "_comment": {"$ref": "#/definitions/comment"}
     },

--- a/schemas/Manual.game.schema.json
+++ b/schemas/Manual.game.schema.json
@@ -34,7 +34,12 @@
         },
         "death_link": {
             "description": "(Optional) Does your game support Deathlink?",
-            "type": "boolean"
+            "type": "boolean",
+            "default": false
+        },
+        "starting_index": {
+            "description": "(Optional) (Advanced) Choose the starting index for your locations and items.\nWhen not included uses the old system to generate a unique starting index",
+            "type": "integer"
         },
         "_comment": {"$ref": "#/definitions/comment"}
     },

--- a/src/Game.py
+++ b/src/Game.py
@@ -7,27 +7,10 @@ game_name = "Manual_%s_%s" % (game_table["game"], game_table["player"])
 filler_item_name = game_table["filler_item_name"] if "filler_item_name" in game_table else "Filler"
 starting_items = game_table["starting_items"] if "starting_items" in game_table else None
 
-if "starting_index" not in game_table:
-# Programmatically generate starting indexes for items and locations based upon the game name and player name to aim for non-colliding indexes
-# Additionally, make this use as many characters of the game name as possible to avoid accidental id pool collisions
-# - It's assumed that the first two characters of a game and the last character *should* be fairly unique, but we use the remaining characters anyways to move the pool
-# - The player name is meant to be a small differentiator, so we just apply a flat multiplier for that
-
-# 100m + 70m + 10m, which should put all Manual games comfortably in the billions
-    starting_index = (ord(game_table["game"][:1]) * 100000000) + \
-        (ord(game_table["game"][1:2]) * 70000000) + \
-        (ord(game_table["game"][-1:]) * 10000000)
-
-    if len(game_table["game"]) > 3:
-        for index in range(2, len(game_table["game"]) - 1):
-            multiplier = 100000
-
-            starting_index += (ord(game_table["game"][index:index+1]) * multiplier)
-
-    for index in range(0, len(game_table["player"])):
-        starting_index += (ord(game_table["player"][index:index+1]) * 1000)
-else:
+if "starting_index" in game_table:
     try:
         starting_index = int(game_table["starting_index"])
     except ValueError:
         raise Exception("The value of data/game.json:'starting_index' should be an int")
+else:
+    starting_index = 1

--- a/src/Game.py
+++ b/src/Game.py
@@ -7,21 +7,27 @@ game_name = "Manual_%s_%s" % (game_table["game"], game_table["player"])
 filler_item_name = game_table["filler_item_name"] if "filler_item_name" in game_table else "Filler"
 starting_items = game_table["starting_items"] if "starting_items" in game_table else None
 
+if "starting_index" not in game_table:
 # Programmatically generate starting indexes for items and locations based upon the game name and player name to aim for non-colliding indexes
 # Additionally, make this use as many characters of the game name as possible to avoid accidental id pool collisions
 # - It's assumed that the first two characters of a game and the last character *should* be fairly unique, but we use the remaining characters anyways to move the pool
 # - The player name is meant to be a small differentiator, so we just apply a flat multiplier for that
 
 # 100m + 70m + 10m, which should put all Manual games comfortably in the billions
-starting_index = (ord(game_table["game"][:1]) * 100000000) + \
-    (ord(game_table["game"][1:2]) * 70000000) + \
-    (ord(game_table["game"][-1:]) * 10000000)
+    starting_index = (ord(game_table["game"][:1]) * 100000000) + \
+        (ord(game_table["game"][1:2]) * 70000000) + \
+        (ord(game_table["game"][-1:]) * 10000000)
 
-if len(game_table["game"]) > 3:
-    for index in range(2, len(game_table["game"]) - 1):
-        multiplier = 100000
+    if len(game_table["game"]) > 3:
+        for index in range(2, len(game_table["game"]) - 1):
+            multiplier = 100000
 
-        starting_index += (ord(game_table["game"][index:index+1]) * multiplier)
+            starting_index += (ord(game_table["game"][index:index+1]) * multiplier)
 
-for index in range(0, len(game_table["player"])):
-    starting_index += (ord(game_table["player"][index:index+1]) * 1000)
+    for index in range(0, len(game_table["player"])):
+        starting_index += (ord(game_table["player"][index:index+1]) * 1000)
+else:
+    try:
+        starting_index = int(game_table["starting_index"])
+    except ValueError:
+        raise Exception("The value of data/game.json:'starting_index' should be an int")


### PR DESCRIPTION
A simple way to set the id offset
when not specified the id offset is decided using the current system.
As of writing this PR its done by adding `"starting_index": int` in game.json but that could be changed

we might need #72 to be merged before this one so the client work with id being the same between multiple manual
idk im not a client side dev I just did what the deprecation notice message said to do.