### PR TITLE
Add auto send

### DIFF
--- a/schemas/Manual.game.schema.json
+++ b/schemas/Manual.game.schema.json
@@ -36,6 +36,10 @@
             "description": "(Optional) Does your game support Deathlink?",
             "type": "boolean"
         },
+        "auto_send": {
+            "description": "(Optional) Will your client automatically send in-logic checks? WARNING: This should only be used for non-game manual worlds.",
+            "type": "boolean"
+        }
         "_comment": {"$ref": "#/definitions/comment"}
     },
     "required":["game", "filler_item_name"],

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -51,7 +51,7 @@ class ManualContext(SuperContext):
     last_death_link = 0
     deathlink_out = False
     
-    auto_release = False
+    auto_send = False
 
     def __init__(self, server_address, password, game, player_name) -> None:
         super(ManualContext, self).__init__(server_address, password)
@@ -157,8 +157,8 @@ class ManualContext(SuperContext):
                     self.ui.enable_death_link()
                     self.set_deathlink = True
                     self.last_death_link = 0
-                if args['slot_data'].get('auto_release'):
-                    self.auto_release = True
+                if args['slot_data'].get('auto_send'):
+                    self.auto_send = True
                 logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()
@@ -568,7 +568,7 @@ class ManualContext(SuperContext):
                                         if location_button.text not in (self.ctx.location_table or AutoWorldRegister.world_types[self.ctx.game].location_name_to_location):
                                             category_count += 1
                                             if location_button.victory and "__Victory__" in self.ctx.tracker_reachable_events:
-                                                if self.ctx.auto_release:
+                                                if self.ctx.auto_send:
                                                     self.location_button_callback(location_button.id, location_button)
                                                 location_button.background_color=[2/255, 242/255, 42/255, 1]
                                                 reachable_count += 1
@@ -582,7 +582,7 @@ class ManualContext(SuperContext):
                                             continue
 
                                         if location_button.text in self.ctx.tracker_reachable_locations:
-                                            if self.ctx.auto_release:
+                                            if self.ctx.auto_send:
                                                 self.location_button_callback(location_button.id, location_button)
                                             location_button.background_color=[2/255, 242/255, 42/255, 1]
                                             reachable_count += 1

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -50,6 +50,8 @@ class ManualContext(SuperContext):
     set_deathlink = False
     last_death_link = 0
     deathlink_out = False
+    
+    auto_release = False
 
     def __init__(self, server_address, password, game, player_name) -> None:
         super(ManualContext, self).__init__(server_address, password)
@@ -155,6 +157,8 @@ class ManualContext(SuperContext):
                     self.ui.enable_death_link()
                     self.set_deathlink = True
                     self.last_death_link = 0
+                if args['slot_data'].get('auto_release'):
+                    self.auto_release = True
                 logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()
@@ -564,6 +568,8 @@ class ManualContext(SuperContext):
                                         if location_button.text not in (self.ctx.location_table or AutoWorldRegister.world_types[self.ctx.game].location_name_to_location):
                                             category_count += 1
                                             if location_button.victory and "__Victory__" in self.ctx.tracker_reachable_events:
+                                                if self.ctx.auto_release:
+                                                    self.location_button_callback(location_button.id, location_button)
                                                 location_button.background_color=[2/255, 242/255, 42/255, 1]
                                                 reachable_count += 1
                                             continue
@@ -576,6 +582,8 @@ class ManualContext(SuperContext):
                                             continue
 
                                         if location_button.text in self.ctx.tracker_reachable_locations:
+                                            if self.ctx.auto_release:
+                                                self.location_button_callback(location_button.id, location_button)
                                             location_button.background_color=[2/255, 242/255, 42/255, 1]
                                             reachable_count += 1
                                         else:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,7 @@ import Utils
 from worlds.generic.Rules import forbid_items_for_player
 from worlds.LauncherComponents import Component, SuffixIdentifier, components, Type, launch_subprocess
 
-from .Data import item_table, location_table, region_table, category_table, meta_table
+from .Data import item_table, location_table, region_table, category_table, meta_table, game_table
 from .Game import game_name, filler_item_name, starting_items
 from .Meta import world_description, world_webworld, enable_region_diagram
 from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups, victory_names
@@ -310,7 +310,8 @@ class ManualWorld(World):
     def fill_slot_data(self):
         slot_data = before_fill_slot_data({}, self, self.multiworld, self.player)
 
-        # slot_data["DeathLink"] = bool(self.multiworld.death_link[self.player].value)
+        if game_table.get("auto_send"):
+            slot_data["auto_send"] = True
         common_options = set(PerGameCommonOptions.type_hints.keys())
         for option_key, _ in self.options_dataclass.type_hints.items():
             if option_key in common_options:


### PR DESCRIPTION
Add a flag to enable your .apworld to automatically send out checks that are in logic

Requires Universal Tracker

NOTE: I intentionally did not add the `auto_send` flag to the template `game.json` file because I don't want it to be turned on by accident. 