### PR TITLE
Allow items to skip IDs

### DIFF
--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -94,6 +94,10 @@
                     "type": ["boolean", "integer"],
                     "default": false
                 },
+                "id": {
+                    "description": "(Optional) Skips the item ID forward to the given value.\nThis can be used to provide buffer space for future items.",
+                    "type": "integer"
+                },
                 "_comment": {"$ref": "#/definitions/comment"}
             },
             "required": ["name"]

--- a/schemas/Manual.locations.schema.json
+++ b/schemas/Manual.locations.schema.json
@@ -92,6 +92,10 @@
                     "type": "boolean",
                     "default": false
                 },
+                "id": {
+                    "description": "(Optional) Skips the item ID forward to the given value.\nThis can be used to provide buffer space for future items.",
+                    "type": "integer"
+                },
                 "_comment": {"$ref": "#/definitions/comment"}
             }
         },

--- a/src/Items.py
+++ b/src/Items.py
@@ -28,11 +28,11 @@ for key, val in enumerate(item_table):
     if "id" in item_table[key]:
         item_id = item_table[key]["id"]
         if item_id > count:
-            item_table[key]["id"] = item_id
+            count = item_id
         else:
             raise ValueError(f"{item_table[key]['name']} has an invalid ID. ID must be at least {count + 1}")
-    else:
-        item_table[key]["id"] = count
+
+    item_table[key]["id"] = count
     item_table[key]["progression"] = val["progression"] if "progression" in val else False
     count += 1
 

--- a/src/Items.py
+++ b/src/Items.py
@@ -25,7 +25,14 @@ if filler_item_name:
 
 # add sequential generated ids to the lists
 for key, val in enumerate(item_table):
-    item_table[key]["id"] = count
+    if "id" in item_table[key]:
+        item_id = item_table[key]["id"]
+        if item_id > count:
+            item_table[key]["id"] = item_id
+        else:
+            raise ValueError(f"{item_table[key]['name']} has an invalid ID. ID must be at least {count + 1}")
+    else:
+        item_table[key]["id"] = count
     item_table[key]["progression"] = val["progression"] if "progression" in val else False
     count += 1
 

--- a/src/Items.py
+++ b/src/Items.py
@@ -27,7 +27,7 @@ if filler_item_name:
 for key, val in enumerate(item_table):
     if "id" in item_table[key]:
         item_id = item_table[key]["id"]
-        if item_id > count:
+        if item_id >= count:
             count = item_id
         else:
             raise ValueError(f"{item_table[key]['name']} has an invalid ID. ID must be at least {count + 1}")

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -17,7 +17,15 @@ for key, _ in enumerate(location_table):
     if "victory" in location_table[key] and location_table[key]["victory"]:
         victory_names.append(location_table[key]["name"])
 
-    location_table[key]["id"] = count
+    if "id" in location_table[key]:
+        item_id = location_table[key]["id"]
+        if item_id > count:
+            location_table[key]["id"] = item_id
+        else:
+            raise ValueError(f"{location_table[key]['name']} has an invalid ID. ID must be at least {count + 1}")
+    else:
+        location_table[key]["id"] = count
+
 
     if not "region" in location_table[key]:
         location_table[key]["region"] = "Manual" # all locations are in the same region for Manual

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -20,12 +20,11 @@ for key, _ in enumerate(location_table):
     if "id" in location_table[key]:
         item_id = location_table[key]["id"]
         if item_id > count:
-            location_table[key]["id"] = item_id
+            count = item_id
         else:
             raise ValueError(f"{location_table[key]['name']} has an invalid ID. ID must be at least {count + 1}")
-    else:
-        location_table[key]["id"] = count
 
+    location_table[key]["id"] = count
 
     if not "region" in location_table[key]:
         location_table[key]["region"] = "Manual" # all locations are in the same region for Manual

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -19,7 +19,7 @@ for key, _ in enumerate(location_table):
 
     if "id" in location_table[key]:
         item_id = location_table[key]["id"]
-        if item_id > count:
+        if item_id >= count:
             count = item_id
         else:
             raise ValueError(f"{location_table[key]['name']} has an invalid ID. ID must be at least {count + 1}")


### PR DESCRIPTION
This is useful both for providing buffer space for future expansion (without shifting later IDs), and also just nice for organization reasons.

It's also an alternative to #73 