### PR TITLE
Remove table_processed hooks in favor of Data hooks

### DIFF
--- a/src/Items.py
+++ b/src/Items.py
@@ -1,9 +1,7 @@
 from BaseClasses import Item
 from .Data import item_table
 from .Game import filler_item_name, starting_index
-from .hooks.Items import before_item_table_processed
 
-item_table = before_item_table_processed(item_table)
 
 ######################
 # Generate item lookups

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -1,9 +1,7 @@
 from BaseClasses import Location
 from .Data import location_table
 from .Game import starting_index
-from .hooks.Locations import before_location_table_processed
 
-location_table = before_location_table_processed(location_table)
 
 ######################
 # Generate location lookups

--- a/src/Regions.py
+++ b/src/Regions.py
@@ -3,7 +3,7 @@ from .Helpers import is_category_enabled, is_location_enabled
 from .Data import region_table
 from .Locations import ManualLocation, location_name_to_location
 from worlds.AutoWorld import World
-from .hooks.Regions import before_region_table_processed
+
 
 if not region_table:
     region_table = {}
@@ -19,7 +19,6 @@ regionMap["Manual"] = {
     "connects_to": starting_regions
 }
 
-regionMap = before_region_table_processed(regionMap)
 
 def create_regions(world: World, multiworld: MultiWorld, player: int):
     # Create regions and assign locations to each region

--- a/src/hooks/Items.py
+++ b/src/hooks/Items.py
@@ -1,5 +1,0 @@
-
-# called after the items.json has been imported, but before ids, etc. have been assigned
-# if you need access to the items after processing to add ids, etc., you should use the hooks in World.py
-def before_item_table_processed(item_table: list) -> list:
-    return item_table

--- a/src/hooks/Locations.py
+++ b/src/hooks/Locations.py
@@ -1,5 +1,0 @@
-
-# called after the locations.json has been imported, but before ids, etc. have been assigned
-# if you need access to the locations after processing to add ids, etc., you should use the hooks in World.py
-def before_location_table_processed(location_table: list) -> list:
-    return location_table

--- a/src/hooks/Regions.py
+++ b/src/hooks/Regions.py
@@ -1,5 +1,0 @@
-
-# called after the regions.json has been imported, but before ids, etc. have been assigned
-# if you need access to the locations after processing to add ids, etc., you should use the hooks in World.py
-def before_region_table_processed(region_table: dict) -> dict:
-    return region_table


### PR DESCRIPTION
The `*_table_processed_hook` functions existed for Items.py, Locations.py, and Regions.py, and allowed power users to hook right before the items/locations/regions are processed individually after data import. However... there's nothing that happens between data import and the start of processing of those things. So the individual `*_table_processed_hook` functions are only different from the generic Data `after_load_*_file` functions in that they let you modify the tables in a non-persistent way (since init loads tables from Data) ... which leads to the table being out of sync with the lookup tables, which is probably always bad.

Also, the existence of these hooks often pushes hook devs to look at using these first instead of the Data hooks, which is not ideal (for above non-persistence reasons).

### tl;dr - It's more correct to use the Data.py hooks than to use these, so removing these.

If people are using these, the migration path is simply to move their hook code to the corresponding Data function instead.