### PR TITLE
Make JSON files identify their data type so a proper empty value is returned

### DIFF
--- a/src/Data.py
+++ b/src/Data.py
@@ -20,6 +20,9 @@ def load_data_file(*args) -> dict:
     except:
         filedata = []
 
+        if args[0] in ['game.json', 'regions.json', 'categories.json', 'meta.json']:
+            filedata = {}
+
     return filedata
 
 def convert_to_list(data, property_name: str) -> list:

--- a/src/Data.py
+++ b/src/Data.py
@@ -11,6 +11,7 @@ from .hooks.Data import \
     after_load_region_file, after_load_category_file, \
     after_load_meta_file
 
+
 # blatantly copied from the minecraft ap world because why not
 def load_data_file(*args) -> dict:
     fname = os.path.join("data", *args)
@@ -20,9 +21,6 @@ def load_data_file(*args) -> dict:
     except:
         filedata = []
 
-        if args[0] in ['game.json', 'regions.json', 'categories.json', 'meta.json']:
-            filedata = {}
-
     return filedata
 
 def convert_to_list(data, property_name: str) -> list:
@@ -30,12 +28,30 @@ def convert_to_list(data, property_name: str) -> list:
         data = data.get(property_name, [])
     return data
 
-game_table = load_data_file('game.json') #dict
-item_table = convert_to_list(load_data_file('items.json'), 'data') #list
-location_table = convert_to_list(load_data_file('locations.json'), 'data') #list
-region_table = load_data_file('regions.json') #dict
-category_table = load_data_file('categories.json') or {} #dict
-meta_table = load_data_file('meta.json') or {} #dict
+
+class ManualFile:
+    filename: str
+    data_type: dict|list
+    
+    def __init__(self, filename, data_type):
+        self.filename = filename
+        self.data_type = data_type
+
+    def load(self):
+        contents = load_data_file(self.filename)
+        
+        if not contents and type(contents) != self.data_type:
+            return self.data_type()
+        
+        return contents
+
+
+game_table = ManualFile('game.json', dict).load() #dict
+item_table = convert_to_list(ManualFile('items.json', list).load(), 'data') #list
+location_table = convert_to_list(ManualFile('locations.json', list).load(), 'data') #list
+region_table = ManualFile('regions.json', dict).load() #dict
+category_table = ManualFile('categories.json', dict).load() #dict
+meta_table = ManualFile('meta.json', dict).load() #dict
 
 # Removal of schemas in root of tables
 region_table.pop('$schema', '')


### PR DESCRIPTION
So... I was doing weird stuff with a Manual where I deleted all the JSON files. And I got an error related to the pop() calls on the region and category table, because `load_data_file` returns `[]` whenever an exception is encountered.

So this PR makes each file indicate which type their contents should be, then they ensure that the default empty contents returned are of the type expected.

(Also, I could've moved `load_data_file` into the new class, but it seems useful as a utility method for people. And I'm also using it in my aforementioned Manual. 😃)