### PR TITLE
Client: Highlight categories when locations in logic

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -51,6 +51,17 @@ class ManualContext(SuperContext):
     last_death_link = 0
     deathlink_out = False
 
+    colors = {
+        'location_default': [219/255, 218/255, 213/255, 1],
+        'location_in_logic': [2/255, 242/255, 42/255, 1],
+        'category_even_default': [0.5, 0.5, 0.5, 0.1],
+        'category_odd_default': [1.0, 1.0, 1.0, 0.0],
+        'category_in_logic': [2/255, 82/255, 2/255, 1],
+        'deathlink_received': [1, 0, 0, 1],
+        'deathlink_primed': [1, 1, 1, 1],
+        'deathlink_sent': [0, 1, 0, 1]
+    }
+
     def __init__(self, server_address, password, game, player_name) -> None:
         super(ManualContext, self).__init__(server_address, password)
 
@@ -167,7 +178,7 @@ class ManualContext(SuperContext):
     def on_deathlink(self, data: typing.Dict[str, typing.Any]) -> None:
         super().on_deathlink(data)
         self.ui.death_link_button.text = f"Death Link: {data['source']}"
-        self.ui.death_link_button.background_color = [1, 0, 0, 1]
+        self.ui.death_link_button.background_color = self.colors['deathlink_received']
 
 
     def on_tracker_updated(self, reachable_locations: list[str]):
@@ -294,11 +305,11 @@ class ManualContext(SuperContext):
                 if self.ctx.last_death_link:
                     self.ctx.last_death_link = 0
                     self.death_link_button.text = "Death Link: Primed"
-                    self.death_link_button.background_color = [1, 1, 1, 1]
+                    self.death_link_button.background_color = self.ctx.colors['deathlink_primed']
                 else:
                     self.ctx.deathlink_out = True
                     self.death_link_button.text = "Death Link: Sent"
-                    self.death_link_button.background_color = [0, 1, 0, 1]
+                    self.death_link_button.background_color = self.ctx.colors['deathlink_sent']
 
             def update_hints(self):
                 super().update_hints()
@@ -564,7 +575,7 @@ class ManualContext(SuperContext):
                                         if location_button.text not in (self.ctx.location_table or AutoWorldRegister.world_types[self.ctx.game].location_name_to_location):
                                             category_count += 1
                                             if location_button.victory and "__Victory__" in self.ctx.tracker_reachable_events:
-                                                location_button.background_color=[2/255, 242/255, 42/255, 1]
+                                                location_button.background_color = self.ctx.colors['location_in_logic']
                                                 reachable_count += 1
                                             continue
 
@@ -576,10 +587,10 @@ class ManualContext(SuperContext):
                                             continue
 
                                         if location_button.text in self.ctx.tracker_reachable_locations:
-                                            location_button.background_color=[2/255, 242/255, 42/255, 1]
+                                            location_button.background_color = self.ctx.colors['location_in_logic']
                                             reachable_count += 1
                                         else:
-                                            location_button.background_color=[219/255, 218/255, 213/255, 1]
+                                            location_button.background_color = self.ctx.colors['location_default']
 
                                         category_count += 1
 
@@ -601,6 +612,15 @@ class ManualContext(SuperContext):
 
                                 category_name = re.sub(r"\s\(\d+\/?(\d+)?\)$", "", category_label.text)
                                 category_label.text = "%s (%s)" % (category_name, count_text)
+
+                                if reachable_count > 0:
+                                    # treeviewlabels don't have background color. because #justkivythings.
+                                    category_label.even_color = self.ctx.colors['category_in_logic']
+                                    category_label.odd_color = self.ctx.colors['category_in_logic']
+                                else:
+                                    category_label.even_color = self.ctx.colors['category_even_default']
+                                    category_label.odd_color = self.ctx.colors['category_odd_default']
+
                                 category_scrollview.size=(Window.width / 2, scrollview_height)
 
             def location_button_callback(self, location_id, button):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -420,7 +420,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_08_11 # YYYYMMDD
+    version = 2024_09_19 # YYYYMMDD
     found = False
     for c in components:
         if c.display_name == "Manual Client":


### PR DESCRIPTION
Feature request from: https://discord.com/channels/1097532591650910289/1277429329952772149

From the request:
> Currently, with UT included Manual will highlight individual items that are currently in logic. Would it be possible to make the CATEGORY highlight when it has one or more items within it that are in logic? When there is a large list of categories it can be pretty easy to miss that one has items available, but this would make it a lot more obvious.

So, this PR does that. Also names all the colors that we're using for background colors in the client, so they're all in one place (i.e., not being copied around) and it's more clear what they're used for.