### PR TITLE
`get_filler_item_name()` hook doesn't pass in world variables

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -63,7 +63,7 @@ class ManualWorld(World):
     victory_names = victory_names
 
     def get_filler_item_name(self) -> str:
-        return hook_get_filler_item_name() or filler_item_name
+        return hook_get_filler_item_name(self, self.multiworld, self.player) or filler_item_name
 
     def interpret_slot_data(self, slot_data: dict[str, any]):
         #this is called by tools like UT

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -33,7 +33,7 @@ import logging
 
 # Use this function to change the valid filler items to be created to replace item links or starting items.
 # Default value is the `filler_item_name` from game.json
-def hook_get_filler_item_name() -> str | bool:
+def hook_get_filler_item_name(world: World, multiworld: MultiWorld, player: int) -> str | bool:
     return False
 
 # Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.


### PR DESCRIPTION
Went to use the `hook_get_filler_item_name` for something and realized I didn't have access to any of the usual world stuff, haha.

So this PR adds the usual world / mw / player args to the hook method so they're available for use in the hook.