### PR TITLE
Filler placement at end of `create_items` should also use `get_filler_item_name()`

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -105,7 +105,9 @@ class ManualWorld(World):
         configured_item_names = self.item_id_to_name.copy()
 
         for name in configured_item_names.values():
+            # victory gets placed via place_locked_item at the victory location in create_regions
             if name == "__Victory__": continue
+            # the game.json filler item name is added to the item lookup, so skip it until it's potentially needed later
             if name == filler_item_name: continue
 
             item = self.item_name_to_item[name]
@@ -355,8 +357,10 @@ class ManualWorld(World):
                 extra_item = self.create_item(self.random.choice(traps))
                 item_pool.append(extra_item)
 
+            filler_name_to_add = self.get_filler_item_name()
+
             for _ in range(0, filler_count):
-                extra_item = self.create_item(filler_item_name)
+                extra_item = self.create_item(filler_name_to_add)
                 item_pool.append(extra_item)
         elif extras < 0:
             logging.warning(f"{self.game} has more items than locations. {abs(extras)} non-progression items will be removed at random.")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -53,6 +53,8 @@ class ManualWorld(World):
     item_name_to_item = item_name_to_item
     item_name_groups = item_name_groups
 
+    filler_item_name = filler_item_name
+
     item_counts = {}
     start_inventory = {}
 
@@ -63,7 +65,7 @@ class ManualWorld(World):
     victory_names = victory_names
 
     def get_filler_item_name(self) -> str:
-        return hook_get_filler_item_name(self, self.multiworld, self.player) or filler_item_name
+        return hook_get_filler_item_name(self, self.multiworld, self.player) or self.filler_item_name
 
     def interpret_slot_data(self, slot_data: dict[str, any]):
         #this is called by tools like UT
@@ -108,7 +110,7 @@ class ManualWorld(World):
             # victory gets placed via place_locked_item at the victory location in create_regions
             if name == "__Victory__": continue
             # the game.json filler item name is added to the item lookup, so skip it until it's potentially needed later
-            if name == filler_item_name: continue
+            if name == filler_item_name: continue # intentionally using the Game.py filler_item_name here because it's a non-Items item
 
             item = self.item_name_to_item[name]
             item_count = int(item.get("count", 1))
@@ -357,10 +359,8 @@ class ManualWorld(World):
                 extra_item = self.create_item(self.random.choice(traps))
                 item_pool.append(extra_item)
 
-            filler_name_to_add = self.get_filler_item_name()
-
             for _ in range(0, filler_count):
-                extra_item = self.create_item(filler_name_to_add)
+                extra_item = self.create_item(self.get_filler_item_name())
                 item_pool.append(extra_item)
         elif extras < 0:
             logging.warning(f"{self.game} has more items than locations. {abs(extras)} non-progression items will be removed at random.")


### PR DESCRIPTION
Realized from the upgrade steps that we're prepping for the unstable that `get_filler_item_name()` is only currently used for item links and `start_item_from_pool`. However, it doesn't really make sense to have the potential for the extras filler (that pads the item pool when they're short on items) to be different from the result of `get_filler_item_name()`.

So this PR makes the default addition of filler at the end of the create_items block in Manual also use `get_filler_item_name()` instead of using the game.json filler_item_name directly.