### PR TITLE
Detangling helper.py

### DIFF
--- a/src/Data.py
+++ b/src/Data.py
@@ -1,7 +1,7 @@
 import logging
 
 from .DataValidation import DataValidation, ValidationError
-from .Helpers import load_data_file
+from .Helpers import load_data_file as helpers_load_data_file
 
 from .hooks.Data import \
     after_load_game_file, \
@@ -9,7 +9,10 @@ from .hooks.Data import \
     after_load_region_file, after_load_category_file, \
     after_load_meta_file
 
-
+# blatantly copied from the minecraft ap world because why not
+def load_data_file(*args) -> dict:
+    logging.warning("Deprecated usage of importing load_data_file from Data.py uses the one from Helper.py instead")
+    return helpers_load_data_file(*args)
 
 def convert_to_list(data, property_name: str) -> list:
     if isinstance(data, dict):
@@ -26,7 +29,7 @@ class ManualFile:
         self.data_type = data_type
 
     def load(self):
-        contents = load_data_file(self.filename)
+        contents = helpers_load_data_file(self.filename)
 
         if not contents and type(contents) != self.data_type:
             return self.data_type()

--- a/src/Data.py
+++ b/src/Data.py
@@ -1,9 +1,7 @@
-import json
 import logging
-import os
-import pkgutil
 
 from .DataValidation import DataValidation, ValidationError
+from .Helpers import load_data_file
 
 from .hooks.Data import \
     after_load_game_file, \
@@ -12,16 +10,6 @@ from .hooks.Data import \
     after_load_meta_file
 
 
-# blatantly copied from the minecraft ap world because why not
-def load_data_file(*args) -> dict:
-    fname = os.path.join("data", *args)
-
-    try:
-        filedata = json.loads(pkgutil.get_data(__name__, fname).decode())
-    except:
-        filedata = []
-
-    return filedata
 
 def convert_to_list(data, property_name: str) -> list:
     if isinstance(data, dict):
@@ -32,17 +20,17 @@ def convert_to_list(data, property_name: str) -> list:
 class ManualFile:
     filename: str
     data_type: dict|list
-    
+
     def __init__(self, filename, data_type):
         self.filename = filename
         self.data_type = data_type
 
     def load(self):
         contents = load_data_file(self.filename)
-        
+
         if not contents and type(contents) != self.data_type:
             return self.data_type()
-        
+
         return contents
 
 

--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -3,11 +3,15 @@ import pkgutil
 import json
 
 from BaseClasses import MultiWorld, Item, Location
-from typing import Optional, List
+from typing import Optional, List, TYPE_CHECKING
 from worlds.AutoWorld import World
 from .hooks.Helpers import before_is_category_enabled, before_is_item_enabled, before_is_location_enabled
 
 from typing import Union
+
+if TYPE_CHECKING:
+    from .Items import ManualItem
+    from .Locations import ManualLocation
 
 # blatantly copied from the minecraft ap world because why not
 def load_data_file(*args) -> dict:
@@ -69,7 +73,7 @@ def is_item_name_enabled(multiworld: MultiWorld, player: int, item_name: str) ->
 
     return is_item_enabled(multiworld, player, item)
 
-def is_item_enabled(multiworld: MultiWorld, player: int, item: Item) -> bool:
+def is_item_enabled(multiworld: MultiWorld, player: int, item: "ManualItem") -> bool:
     """Check if an item has been disabled by a yaml option."""
     hook_result = before_is_item_enabled(multiworld, player, item)
     if hook_result is not None:
@@ -85,7 +89,7 @@ def is_location_name_enabled(multiworld: MultiWorld, player: int, location_name:
 
     return is_location_enabled(multiworld, player, location)
 
-def is_location_enabled(multiworld: MultiWorld, player: int, location: Location) -> bool:
+def is_location_enabled(multiworld: MultiWorld, player: int, location: "ManualLocation") -> bool:
     """Check if a location has been disabled by a yaml option."""
     hook_result = before_is_location_enabled(multiworld, player, location)
     if hook_result is not None:

--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -1,12 +1,24 @@
-from BaseClasses import MultiWorld, Item
+import os
+import pkgutil
+import json
+
+from BaseClasses import MultiWorld, Item, Location
 from typing import Optional, List
 from worlds.AutoWorld import World
-from .Data import category_table
-from .Items import ManualItem
-from .Locations import ManualLocation
 from .hooks.Helpers import before_is_category_enabled, before_is_item_enabled, before_is_location_enabled
 
 from typing import Union
+
+# blatantly copied from the minecraft ap world because why not
+def load_data_file(*args) -> dict:
+    fname = os.path.join("data", *args)
+
+    try:
+        filedata = json.loads(pkgutil.get_data(__name__, fname).decode())
+    except:
+        filedata = []
+
+    return filedata
 
 def is_option_enabled(multiworld: MultiWorld, player: int, name: str) -> bool:
     return get_option_value(multiworld, player, name) > 0
@@ -28,6 +40,7 @@ def clamp(value, min, max):
         return value
 
 def is_category_enabled(multiworld: MultiWorld, player: int, category_name: str) -> bool:
+    from .Data import category_table
     """Check if a category has been disabled by a yaml option."""
     hook_result = before_is_category_enabled(multiworld, player, category_name)
     if hook_result is not None:
@@ -56,7 +69,7 @@ def is_item_name_enabled(multiworld: MultiWorld, player: int, item_name: str) ->
 
     return is_item_enabled(multiworld, player, item)
 
-def is_item_enabled(multiworld: MultiWorld, player: int, item: ManualItem) -> bool:
+def is_item_enabled(multiworld: MultiWorld, player: int, item: Item) -> bool:
     """Check if an item has been disabled by a yaml option."""
     hook_result = before_is_item_enabled(multiworld, player, item)
     if hook_result is not None:
@@ -72,7 +85,7 @@ def is_location_name_enabled(multiworld: MultiWorld, player: int, location_name:
 
     return is_location_enabled(multiworld, player, location)
 
-def is_location_enabled(multiworld: MultiWorld, player: int, location: ManualLocation) -> bool:
+def is_location_enabled(multiworld: MultiWorld, player: int, location: Location) -> bool:
     """Check if a location has been disabled by a yaml option."""
     hook_result = before_is_location_enabled(multiworld, player, location)
     if hook_result is not None:

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -328,7 +328,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
                         value = bool(value)
                         if warn:
                         # warning here spam the console if called from rules.py, might be worth to make it a data validation instead
-                            logging.warn(f"A call of the {func.__name__} function in '{areaName}'s requirement, asks for a value of type {argType}\nfor its argument '{info.name}' but an unknown string was passed and thus converted to {value}")
+                            logging.warning(f"A call of the {func.__name__} function in '{areaName}'s requirement, asks for a value of type {argType}\nfor its argument '{info.name}' but an unknown string was passed and thus converted to {value}")
 
                 else:
                     try:

--- a/src/hooks/Helpers.py
+++ b/src/hooks/Helpers.py
@@ -1,5 +1,9 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 from BaseClasses import MultiWorld, Item, Location
+
+if TYPE_CHECKING:
+    from ..Items import ManualItem
+    from ..Locations import ManualLocation
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the category, False to disable it, or None to use the default behavior
@@ -8,10 +12,10 @@ def before_is_category_enabled(multiworld: MultiWorld, player: int, category_nam
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the item, False to disable it, or None to use the default behavior
-def before_is_item_enabled(multiworld: MultiWorld, player: int, item: Item) -> Optional[bool]:
+def before_is_item_enabled(multiworld: MultiWorld, player: int, item: "ManualItem") -> Optional[bool]:
     return None
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the location, False to disable it, or None to use the default behavior
-def before_is_location_enabled(multiworld: MultiWorld, player: int, location: Location) -> Optional[bool]:
+def before_is_location_enabled(multiworld: MultiWorld, player: int, location: "ManualLocation") -> Optional[bool]:
     return None

--- a/src/hooks/Helpers.py
+++ b/src/hooks/Helpers.py
@@ -1,8 +1,5 @@
 from typing import Optional
-from BaseClasses import MultiWorld
-from ..Locations import ManualLocation
-from ..Items import ManualItem
-
+from BaseClasses import MultiWorld, Item, Location
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the category, False to disable it, or None to use the default behavior
@@ -11,10 +8,10 @@ def before_is_category_enabled(multiworld: MultiWorld, player: int, category_nam
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the item, False to disable it, or None to use the default behavior
-def before_is_item_enabled(multiworld: MultiWorld, player: int, item: ManualItem) -> Optional[bool]:
+def before_is_item_enabled(multiworld: MultiWorld, player: int, item: Item) -> Optional[bool]:
     return None
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the location, False to disable it, or None to use the default behavior
-def before_is_location_enabled(multiworld: MultiWorld, player: int, location: ManualLocation) -> Optional[bool]:
+def before_is_location_enabled(multiworld: MultiWorld, player: int, location: Location) -> Optional[bool]:
     return None


### PR DESCRIPTION
A lot of the functions in helper.py are really usefull but in some situations importing them caused a circular import. 
Not anymore*

To do so I removed any local (to manual) imports where I could and moved to a specific function where I couldnt

I also left a deprecation notice since I moved load_data_file from data.py to helpers for people (like me) that used it in hooks
|
|
|
\* is because calling is_item/location/category_enabled in data or hooks/data will still be circular but why would you use it there...