### PR TITLE
Add CSV support

### DIFF
--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -1,8 +1,9 @@
+import csv
 import os
 import pkgutil
 import json
 
-from BaseClasses import MultiWorld, Item, Location
+from BaseClasses import MultiWorld, Item
 from typing import Optional, List, TYPE_CHECKING
 from worlds.AutoWorld import World
 from .hooks.Helpers import before_is_category_enabled, before_is_item_enabled, before_is_location_enabled
@@ -21,6 +22,17 @@ def load_data_file(*args) -> dict:
         filedata = json.loads(pkgutil.get_data(__name__, fname).decode())
     except:
         filedata = []
+
+    return filedata
+
+def load_data_csv(*args) -> list[dict]:
+    fname = os.path.join("data", *args)
+
+    try:
+        lines = pkgutil.get_data(__name__, fname).decode().splitlines()
+    except:
+        lines = []
+    filedata = list(csv.DictReader(lines))
 
     return filedata
 

--- a/src/Items.py
+++ b/src/Items.py
@@ -32,6 +32,9 @@ for key, val in enumerate(item_table):
 
     item_table[key]["id"] = count
     item_table[key]["progression"] = val["progression"] if "progression" in val else False
+    if isinstance(val.get("category", []), str):
+        item_table[key]["category"] = [val["category"]]
+        
     count += 1
 
 for item in item_table:

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -24,8 +24,11 @@ for key, _ in enumerate(location_table):
 
     location_table[key]["id"] = count
 
-    if not "region" in location_table[key]:
+    if "region" not in location_table[key]:
         location_table[key]["region"] = "Manual" # all locations are in the same region for Manual
+
+    if isinstance(location_table[key].get("category", []), str):
+        location_table[key]["category"] = [location_table[key]["category"]]
 
     count += 1
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -221,6 +221,9 @@ class ManualWorld(World):
         if "progression_skip_balancing" in item and item["progression_skip_balancing"]:
             classification = ItemClassification.progression_skip_balancing
 
+        if "classification" in item:
+            classification = ItemClassification[item["classification"]]
+
         item_object = ManualItem(name, classification,
                         self.item_name_to_id[name], player=self.player)
 

--- a/src/data/categories.json
+++ b/src/data/categories.json
@@ -5,5 +5,8 @@
     },
     "Example Yaml-option category": {
         "yaml_option": ["DLC_enabled"]
+    },
+    "Stage": {
+        "yaml_option": ["randomize_stages"]
     }
 }

--- a/src/data/game.json
+++ b/src/data/game.json
@@ -26,6 +26,10 @@
         {
             "items": ["Deadpool"],
             "yaml_option": ["start_with_deadpool"]
+        },
+        {
+            "item_categories": ["Stage"],
+            "yaml_option": ["randomize_stages"]
         }
     ],
     "death_link": false

--- a/src/data/items.csv
+++ b/src/data/items.csv
@@ -1,0 +1,10 @@
+name,category,classification
+Danger Room,Stage,progression
+Shadowland,Stage,progression
+S.H.I.E.L.D Air Show,Stage,progression
+Asgard: Sea of Space,Stage,progression
+Days of Future Past,Stage,progression
+City that Never Sleeps,Stage,progression
+Chaos at Tricell,Stage,progression
+Demon Village Redux,Stage,progression
+Bonne Wonderland,Stage,progression


### PR DESCRIPTION
This is terrifying, and not the greatest.  However, it is very good for simple things, and I think a lot of people would get value out of it, especially when entering repetitive data.

This PR adds:
* Support for `items.csv` and `locations.csv` (The former is much more useful, but I'm not gonna stop people from using the latter)
* `load_data_csv` helper function.  Hooks users will probably find this useful
* Finally adds a bugfix for when your category is a string rather than a list (Because CSV items will always be a single string)
* Option to use `"classification": "progression"` in your items.  This lets you have a single column, rather than five.


This could definitely be improved.  Off the top of my head:
* Special logic to lowercase headings/values that should be lowercase.
* Support for multiple categories
* Data Validation?

I wrote this on the train ride home from PAX, and was very sleep deprived at the time.  Do we even want it?