### PR TITLE
WIP Itemvalue misc fixes

### DIFF
--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -285,7 +285,7 @@ class DataValidation():
             existing_items = [item for item in get_items_for_player(multiworld, player, True) if item.code is not None and
                         item.classification == ItemClassification.progression or item.classification == ItemClassification.progression_skip_balancing]
             for value, val_count in values_requested.items():
-                items_value = get_items_with_value(world, multiworld, value, player, True)
+                items_value = get_items_with_value(world, multiworld, value, player)
                 found_count = 0
                 if items_value:
                     for item in existing_items:

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -211,6 +211,7 @@ class DataValidation():
     def checkIfEnoughItemsForValue():
         values_available = {}
         values_requested = {}
+        used_regions = set(["Manual"])
 
         # First find the biggest values required by locations
         for location in DataValidation.location_table:
@@ -219,10 +220,38 @@ class DataValidation():
 
             # convert to json so we don't have to guess the data type
             location_requires = json.dumps(location["requires"])
-
+            if location.get('region'):
+                used_regions.add(location['region'])
             DataValidation._checkLocationRequiresForItemValueWithRegex(values_requested, location_requires)
-        # Second, check region requires for the presence of item name
+
+        parent_child = {}
+        # First build a parent-child dictionary:
         for region_name in DataValidation.region_table:
+            region = DataValidation.region_table[region_name]
+
+            region_connect_to = region.get("connects_to", [])
+            for child in region_connect_to:
+                if child not in parent_child.keys():
+                    parent_child[child] = []
+                parent_child[child].append(region_name)
+
+        # add parent and their parent to used_regions recursively if any location is present
+        checked_parent = ['Manual']
+        for region_name in set(used_regions):
+            def checkParent(name):
+                if name in checked_parent: #dont check a region twice
+                    return
+                checked_parent.append(name)
+                if name in parent_child.keys():
+                    for parent in parent_child[name]:
+                        checkParent(parent)
+                        used_regions.add(parent)
+                return
+            checkParent(region_name)
+
+        used_regions.remove('Manual')
+        # Second, check region requires of used regions for the presence of ItemValue
+        for region_name in used_regions:
             region = DataValidation.region_table[region_name]
 
             if "requires" not in region:
@@ -263,12 +292,37 @@ class DataValidation():
         from .Helpers import get_items_with_value, get_items_for_player
         player = world.player
         values_requested = {}
+        player_regions = {}
+        used_regions = set(['Manual'])
 
+        #Grab all the player's regions and take note of those with locations
         for region in multiworld.regions:
             if region.player != player:
                 continue
+            player_regions[region.name] = region
+            if region.locations:
+                used_regions.add(region.name)
 
-            manualregion = DataValidation.region_table.get(region.name, {})
+        #Check every known region with location for parent regions
+        checked_parent = ['Manual']
+        for region_name in set(used_regions):
+            def checkParent(name):
+                region = player_regions[name]
+                if name in checked_parent: #dont check a region twice
+                    return
+                checked_parent.append(name)
+                if region.entrances:
+                    for entrance in region.entrances:
+                        checkParent(entrance.parent_region.name)
+                        used_regions.add(entrance.parent_region.name)
+                return
+            checkParent(region_name)
+
+        used_regions.remove('Manual') #Manual shouldn't have any requires so skip it
+        #Check used regions (and their parent(s)) for ItemValue requirement
+        for region_name in used_regions:
+            region = player_regions[region_name]
+            manualregion = DataValidation.region_table.get(region_name, {})
             if "requires" in manualregion and manualregion["requires"]:
                 region_requires = json.dumps(manualregion["requires"])
 

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -246,7 +246,7 @@ class DataValidation():
                     item_count = '1'
 
                 for key, count in item.get("value", {}).items():
-                    if not values_available.get(key.lower().strip()):
+                    if not values_available.get(key):
                         values_available[key] = 0
                     values_available[key] += int(count) * int(item_count)
 

--- a/src/Items.py
+++ b/src/Items.py
@@ -47,8 +47,12 @@ for item in item_table:
             item_name_groups[c] = []
         item_name_groups[c].append(item_name)
 
+    #Just lowercase the values here to remove all the .lower.strip down the line
+    item['value'] = {k.lower().strip(): v
+                     for k, v in item.get('value', {}).items()}
+
     for v in item.get("value", {}).keys():
-        group_name = f"has_{v.lower().strip()}_value"
+        group_name = f"has_{v}_value"
         if group_name not in item_name_groups:
             item_name_groups[group_name] = []
         item_name_groups[group_name].append(item_name)

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -375,21 +375,21 @@ def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, play
     value_name = valueCount[0].lower().strip()
     requested_count = int(valueCount[1].strip())
 
-    if not hasattr(world, 'item_values_cache'): #Cache made for optimization purposes
-        world.item_values_cache = {}
+    if not hasattr(world, 'itemvalue_rule_cache'): #Cache made for optimization purposes
+        world.itemvalue_rule_cache = {}
 
-    if not world.item_values_cache.get(player, {}):
-        world.item_values_cache[player] = {}
+    if not world.itemvalue_rule_cache.get(player, {}):
+        world.itemvalue_rule_cache[player] = {}
 
     if not skipCache:
-        if not world.item_values_cache[player].get(value_name, {}):
-            world.item_values_cache[player][value_name] = {
+        if not world.itemvalue_rule_cache[player].get(value_name, {}):
+            world.itemvalue_rule_cache[player][value_name] = {
                 'state': {},
                 'count': -1,
                 }
 
-    if (skipCache or world.item_values_cache[player][value_name].get('count', -1) == -1
-            or world.item_values_cache[player][value_name].get('state') != dict(state.prog_items[player])):
+    if (skipCache or world.itemvalue_rule_cache[player][value_name].get('count', -1) == -1
+            or world.itemvalue_rule_cache[player][value_name].get('state') != dict(state.prog_items[player])):
         # Run First Time, if state changed since last check or if skipCache has a value
         existing_item_values = get_items_with_value(world, multiworld, value_name)
         total_Count = 0
@@ -399,9 +399,9 @@ def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, play
                 total_Count += count * value
         if skipCache:
             return total_Count >= requested_count
-        world.item_values_cache[player][value_name]['count'] = total_Count
-        world.item_values_cache[player][value_name]['state'] = dict(state.prog_items[player])
-    return world.item_values_cache[player][value_name]['count'] >= requested_count
+        world.itemvalue_rule_cache[player][value_name]['count'] = total_Count
+        world.itemvalue_rule_cache[player][value_name]['state'] = dict(state.prog_items[player])
+    return world.itemvalue_rule_cache[player][value_name]['count'] >= requested_count
 
 # Two useful functions to make require work if an item is disabled instead of making it inaccessible
 def OptOne(world: World, multiworld: MultiWorld, state: CollectionState, player: int, item: str, items_counts: Optional[dict] = None):


### PR DESCRIPTION
includes multiple small fixes to ItemValue functionality:
2586167 Fixed datavalidation to only check for requirements of used regions 
63605b3 Made it so for sure that value name get lowercased (check items.py)
2b97f9d Renamed world.item_values_cache to world.itemvalue_rule_cache to stop potential confusion with world.item_values 
5e64593 Stopped PreFill Datavalidation of ItemValue from reseting the world.item_values cache when running get_items_with_value so hook user can run it first then edit it to modify an item value for dev reasons 

for some reason the diff of  commit 63605b3 failed the only line changed in datavalidation is [249 -> 278](https://github.com/ManualForArchipelago/Manual/compare/ItemValue-Misc-fixes?expand=1#diff-9e2dd0bc6d4ea837c08d3aabd6126fa53d7ff1982b72ceef74b4f548502144cfR278) 