### PR TITLE
Disable the pre_fill validation for ItemValue for now

### DIFF
--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -450,8 +450,8 @@ def runPreFillDataValidation(world: World, multiworld: MultiWorld):
     validation_errors = []
 
     # check if there is enough items with values
-    try: DataValidation.preFillCheckIfEnoughItemsForValue(world, multiworld)
-    except ValidationError as e: validation_errors.append(e)
+    #try: DataValidation.preFillCheckIfEnoughItemsForValue(world, multiworld)
+    #except ValidationError as e: validation_errors.append(e)
 
     if validation_errors:
         newline = "\n"


### PR DESCRIPTION
Related to this bug report: https://discord.com/channels/1097532591650910289/1307802587839594617

Essentially, the pre_fill validation for ItemValue doesn't account for changes that remove the values entirely, like using categories to disable items. There's some potential merit to making it support that... but that's also, imo, not necessary at all. Because the OTHER validation for ItemValue, which runs at the same time as the rest of validation, does what it's supposed to and identifies common pitfalls.

So this PR comments out the pre_fill validation for ItemValue -- to fix the bugs with category disabling -- until we figure out what we want to do with it. (And when we're figuring out what to do with it, we should figure out if -- and why -- we want pre_fill validation.)