### PR TITLE
Make Item values all be lowercase

### DIFF
--- a/src/Items.py
+++ b/src/Items.py
@@ -47,8 +47,12 @@ for item in item_table:
             item_name_groups[c] = []
         item_name_groups[c].append(item_name)
 
+    #Just lowercase the values here to remove all the .lower.strip down the line
+    item['value'] = {k.lower().strip(): v
+                     for k, v in item.get('value', {}).items()}
+
     for v in item.get("value", {}).keys():
-        group_name = f"has_{v.lower().strip()}_value"
+        group_name = f"has_{v}_value"
         if group_name not in item_name_groups:
             item_name_groups[group_name] = []
         item_name_groups[group_name].append(item_name)


### PR DESCRIPTION
as sugested in #101 it was split in its own PR Still need to find why removing the .lower.strip from key in datavalidation make the diff think I changed the entire file...

to help with some bug in datavalidation make it so values are actually lowercase in the dict
before this most of the ItemValue code did name.lower.strip() everytime