### PR TITLE
Add support for assigning multiple item classifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .vs/
 /*.code-workspace
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .vscode/
 .vs/
 /*.code-workspace
-.idea

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -282,8 +282,8 @@ class DataValidation():
         # compare whats available vs requested but only if there's anything requested
         if values_requested:
             errors = []
-            existing_items = [item for item in get_items_for_player(multiworld, player, True) if item.code is not None and
-                        item.classification == ItemClassification.progression or item.classification == ItemClassification.progression_skip_balancing]
+            existing_items = [item for item in get_items_for_player(multiworld, player, True) if
+                              item.code is not None and ItemClassification.progression in item.classification]
             for value, val_count in values_requested.items():
                 items_value = get_items_with_value(world, multiworld, value, player, True)
                 found_count = 0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -208,19 +208,24 @@ class ManualWorld(World):
         name = before_create_item(name, self, self.multiworld, self.player)
 
         item = self.item_name_to_item[name]
-        classification = ItemClassification.filler
+        filler = ItemClassification.filler
+        trap = ItemClassification.filler
+        useful = ItemClassification.filler
+        progression = ItemClassification.filler
+        progression_skip_balancing = ItemClassification.filler
 
         if "trap" in item and item["trap"]:
-            classification = ItemClassification.trap
+            trap = ItemClassification.trap
 
         if "useful" in item and item["useful"]:
-            classification = ItemClassification.useful
+            useful = ItemClassification.useful
 
         if "progression" in item and item["progression"]:
-            classification = ItemClassification.progression
+            progression = ItemClassification.progression
+        elif "progression_skip_balancing" in item and item["progression_skip_balancing"]:
+            progression_skip_balancing = ItemClassification.progression_skip_balancing
 
-        if "progression_skip_balancing" in item and item["progression_skip_balancing"]:
-            classification = ItemClassification.progression_skip_balancing
+        classification = filler | trap | useful | progression | progression_skip_balancing
 
         item_object = ManualItem(name, classification,
                         self.item_name_to_id[name], player=self.player)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -383,6 +383,9 @@ class ManualWorld(World):
                 item_pool.append(extra_item)
         elif extras < 0:
             logging.warning(f"{self.game} has more items than locations. {abs(extras)} non-progression items will be removed at random.")
+            # Filler is only assigned if the item doesn't have any other tags, so it only has to be covered by itself.
+            # Skip Balancing is also not covered due to how it's only supported when paired with Progression.
+            # As a result, these cover every possible combination can be removed.
             fillers = [item for item in item_pool if item.classification == ItemClassification.filler]
             traps = [item for item in item_pool if item.classification == ItemClassification.trap]
             useful = [item for item in item_pool if item.classification == ItemClassification.useful]
@@ -403,7 +406,6 @@ class ManualWorld(World):
                     popped = traps.pop()
                 elif useful:
                     popped = useful.pop()
-                # Not sure if Useful + Trap should go before or after Useful.
                 elif useful_traps:
                     popped = useful_traps.pop()
                 else:


### PR DESCRIPTION
Adds support for users assigning multiple item classifications to a single item.

This is achieved by taking the base `filler` flag and appending each of the assigned classifications to it, making use of how Manual already 'supported' assigning multiple classifications to an item, but this adjusts the behavior so that they're no longer mutually exclusive.

Tested by assigning all three of the "Progression", "Useful", and "Trap" flags to a single item and then viewing that it displayed with all three in the client. Also verified that Useful + Trap items were correctly removed from the pool when the number of items exceeded the number of locations.