### PR TITLE
Add search box to the client

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -271,7 +271,7 @@ class ManualContext(SuperContext):
         Builder.load_string(
         """
 
-<HeaderLayout>:
+<ManualControlsStyledLayout>:
     canvas:
         Color:
             rgba: root.background_color
@@ -281,7 +281,7 @@ class ManualContext(SuperContext):
 
         """)
 
-        class HeaderLayout(BoxLayout):
+        class ManualControlsStyledLayout(BoxLayout):
             background_color = ColorProperty()
 
         class ManualManager(ui):
@@ -414,7 +414,7 @@ class ManualContext(SuperContext):
                 self.clear_lists()
 
                 # build tab-specific controls above the two tracker columns
-                header_layout = HeaderLayout(orientation="horizontal", size_hint_y=None, height=dp(40), padding=dp(5), background_color=self.ctx.colors["header_background"])
+                controls_styled_layout = ManualControlsStyledLayout(orientation="horizontal", size_hint_y=None, height=dp(40), padding=dp(5), background_color=self.ctx.colors["header_background"])
                 search_layout = BoxLayout(orientation="horizontal", size_hint=(None, None), width=dp(320), height=dp(30), spacing=dp(2))
                 search_label = Label(text="Search:", size_hint=(None, None), width=dp(55), height=dp(30), bold=True)
                 self.search_textbox = TextInput(size_hint=(None, None), width=dp(200), height=dp(30), multiline=False, write_tab=False)
@@ -422,11 +422,11 @@ class ManualContext(SuperContext):
                 search_button = Button(size_hint=(None, None), width=dp(50), height=dp(30), text="Clear")
                 search_button.bind(on_release=lambda *args: self.clear_search_input())
 
-                header_layout.add_widget(search_layout)
+                controls_styled_layout.add_widget(search_layout)
                 search_layout.add_widget(search_label)
                 search_layout.add_widget(self.search_textbox)
                 search_layout.add_widget(search_button)
-                self.controls_panel.add_widget(header_layout)
+                self.controls_panel.add_widget(controls_styled_layout)
 
                 # seed all category names to start
                 for item in self.ctx.item_table.values() or AutoWorldRegister.world_types[self.ctx.game].item_name_to_item.values():

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -552,6 +552,17 @@ class ManualContext(SuperContext):
                 items_length = len(self.ctx.items_received)
                 locations_length = len(self.ctx.missing_locations)
 
+                if self.ctx.search_term:
+                    items_length = len([
+                        i for i in self.ctx.items_received 
+                            if self.ctx.search_term.lower() in self.ctx.item_names.lookup_in_game(i.item).lower()
+                    ])
+
+                    locations_length = len([
+                        l for l in self.ctx.missing_locations 
+                            if self.ctx.search_term.lower() in self.ctx.location_names.lookup_in_game(l).lower()
+                    ])
+
                 for _, child in enumerate(self.tracker_and_locations_panel.children):
                     #
                     # Structure of items:

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -414,12 +414,12 @@ class ManualContext(SuperContext):
 
             def update_search_from_input(self, instance, text: str):
                 self.ctx.set_search(text)
-                self.request_update_tracker_and_locations_table()
+                self.request_update_tracker_and_locations_table() # if we want search to be "snappier", we can just make this update
 
             def clear_search_input(self):
                 self.search_textbox.text = ""
                 self.ctx.clear_search()
-                self.request_update_tracker_and_locations_table()
+                self.request_update_tracker_and_locations_table() # if we want search to be "snappier", we can just make this update
 
             def build_tracker_and_locations_table(self):
                 self.controls_panel.clear_widgets()

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -229,6 +229,12 @@ class ManualContext(SuperContext):
         from kivy.uix.treeview import TreeView, TreeViewNode, TreeViewLabel
         from kivy.core.window import Window
 
+        class ManualTabLayout(BoxLayout):
+            pass
+
+        class ManualControlsLayout(BoxLayout):
+            pass
+
         class TrackerAndLocationsLayout(GridLayout):
             pass
 
@@ -290,7 +296,13 @@ class ManualContext(SuperContext):
                     if child.text == "Manual":
                         panel = child # instead of creating a new TabbedPanelItem, use the one we use above to make the tabs show
 
-                self.tracker_and_locations_panel = panel.content = TrackerAndLocationsLayout(cols = 2)
+                panel.content = ManualTabLayout(orientation="vertical")
+
+                self.controls_panel = ManualControlsLayout(orientation="horizontal", size_hint_y=None, height=dp(30))
+                self.tracker_and_locations_panel = TrackerAndLocationsLayout(cols = 2)
+
+                panel.content.add_widget(self.controls_panel)
+                panel.content.add_widget(self.tracker_and_locations_panel)
 
                 self.build_tracker_and_locations_table()
 
@@ -356,6 +368,7 @@ class ManualContext(SuperContext):
                 self.update_tracker_and_locations_table()
 
             def build_tracker_and_locations_table(self):
+                self.controls_panel.clear_widgets()
                 self.tracker_and_locations_panel.clear_widgets()
 
                 if not self.ctx.server or not self.ctx.auth:
@@ -364,6 +377,14 @@ class ManualContext(SuperContext):
                     return
 
                 self.clear_lists()
+
+                # build tab-specific controls above the two tracker columns
+                search_layout = BoxLayout(orientation="horizontal", size_hint_y=None, height=dp(30), width=dp(200))
+                search_label = Label(text="Search:", size_hint_x=None, width=dp(50))
+                search_textbox = TextInput(size_hint=(None, None), width=dp(150), height=dp(30), multiline=False, write_tab=False)
+                search_layout.add_widget(search_label)
+                search_layout.add_widget(search_textbox)
+                self.controls_panel.add_widget(search_layout)
 
                 # seed all category names to start
                 for item in self.ctx.item_table.values() or AutoWorldRegister.world_types[self.ctx.game].item_name_to_item.values():

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -440,7 +440,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_11_08 # YYYYMMDD
+    version = 2024_11_21 # YYYYMMDD
     found = False
     for c in components:
         if c.display_name == "Manual Client":

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -440,7 +440,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_09_29 # YYYYMMDD
+    version = 2024_11_08 # YYYYMMDD
     found = False
     for c in components:
         if c.display_name == "Manual Client":


### PR DESCRIPTION
From these feature suggestions:
https://discord.com/channels/1097532591650910289/1121577176886677506
https://discord.com/channels/1097532591650910289/1267280387877507154

This PR adds a search box to the Manual tab's view. When the contents of that search box change, the lists are immediately filtered to only results that have a match in the location or item name. Search only searches location/item names, and does not search categories or anything else. (Also, if you're wondering why showing/hiding is the way it is, it's because Kivy is unusable garbage and this was the easiest way to do it.)

This PR also opens the door for more filtering controls or similar, since any other controls can be added alongside the search layout.

---

**Screenshot of Manual client after connecting, with no search term:**

![manual-client-search-empty](https://github.com/user-attachments/assets/9c07f519-6578-4ecf-8ea3-8c2a72fb980b)

**Screenshot of Manual client results after entering a search term:**
_(This screenshot shows the categories expanded so it can be seen that the term matches. The categories are not auto-expanded when a search is performed.)_

![manual-client-search-text](https://github.com/user-attachments/assets/04223358-c137-442c-9095-612398c04b5e)

