### PR TITLE
Add `starting_index` example to game.json

### DIFF
--- a/src/data/game.json
+++ b/src/data/game.json
@@ -28,5 +28,6 @@
             "yaml_option": ["start_with_deadpool"]
         }
     ],
-    "death_link": false
+    "death_link": false,
+    "starting_index": 1
 }


### PR DESCRIPTION
We forgot to provide an example of game.json's new `starting_index` for the example data. So this PR adds that.