### PR TITLE
Sort items and locations alphabetically in the client

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import time
 import sys
-from typing import Any
+from typing import Any, Optional
 import typing
 from worlds import AutoWorldRegister, network_data_package
 import json
@@ -282,7 +282,7 @@ class ManualContext(SuperContext):
             active_item_accordion = 0
             active_location_accordion = 0
 
-            update_requested_time: float = None
+            update_requested_time: Optional[float] = None
             update_requested_highlights: bool = False
 
             ctx: ManualContext

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -446,7 +446,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_11_03 # YYYYMMDD
+    version = 2024_11_22 # YYYYMMDD
     found = False
 
     if "manual" not in icon_paths:


### PR DESCRIPTION
Related feature requests (might be more than this):
https://discord.com/channels/1097532591650910289/1219628970136571974
https://discord.com/channels/1097532591650910289/1166152300771950593

Having the items and locations be sorted is a long-requested feature, since their current orders are kinda arbitrary. So this PR sorts them both alphabetically. If we decide we want to sort them a different way later (or provide options to sort various ways), this at least sets the groundwork for any sort.

Sorting locations was the simple part of this. Basically a one-liner in a for loop.

Sorting items was the harder part of this. In the current client, we leave the existing item labels and only draw the new ones. To sort items easily, we have to instead redraw all of the item labels in their sorted name order. Unfortunately, this ran into an issue because our update function is called about 4-8 times per location send / item receive -- by us, UT, hints, etc. So the bold logic would work on the first update, then get overwritten by the subsequent ones. 

So, this PR also includes functionality that buffers any update requests, then processes them all as a single request after a brief period of 1/4 of a second. Accidental but necessary performance boost :smiley: 