### PR TITLE
Make "Invalid logic format" more descriptive for requires syntax

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -21,7 +21,7 @@ class LogicErrorSource(IntEnum):
     EVALUATE_POSTFIX = 2 # includes missing pipes and missing value on either side of AND/OR
     EVALUATE_STACK_SIZE = 3 # includes missing curly brackets
 
-def raise_logic_error(location_or_region: dict, source: LogicErrorSource):
+def construct_logic_error(location_or_region: dict, source: LogicErrorSource) -> KeyError:
     object_type = "location/region"
     object_name = location_or_region.get("name", "Unknown")
 
@@ -39,7 +39,7 @@ def raise_logic_error(location_or_region: dict, source: LogicErrorSource):
     else:
         source_text = "This requires includes invalid syntax."
 
-    raise KeyError(f"Invalid 'requires' for {object_type} '{object_name}': {source_text} (ERROR {source})")
+    return KeyError(f"Invalid 'requires' for {object_type} '{object_name}': {source_text} (ERROR {source})")
 
 def infix_to_postfix(expr, location):
     prec = {"&": 2, "|": 2, "!": 3}
@@ -64,7 +64,7 @@ def infix_to_postfix(expr, location):
         while stack:
             postfix += stack.pop()
     except Exception:
-        raise_logic_error(location, LogicErrorSource.INFIX_TO_POSTFIX)
+        raise construct_logic_error(location, LogicErrorSource.INFIX_TO_POSTFIX)
 
     return postfix
 
@@ -90,10 +90,10 @@ def evaluate_postfix(expr: str, location: str) -> bool:
                 op = stack.pop()
                 stack.append(not op)
     except Exception:
-        raise_logic_error(location, LogicErrorSource.EVALUATE_POSTFIX)
+        raise construct_logic_error(location, LogicErrorSource.EVALUATE_POSTFIX)
 
     if len(stack) != 1:
-        raise_logic_error(location, LogicErrorSource.EVALUATE_STACK_SIZE)
+        raise construct_logic_error(location, LogicErrorSource.EVALUATE_STACK_SIZE)
 
     return stack.pop()
 

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -25,10 +25,9 @@ def raise_logic_error(location_or_region: dict, source: LogicErrorSource):
     object_type = "location/region"
     object_name = location_or_region.get("name", "Unknown")
 
-    if "region_name" in location_or_region or "starting" in location_or_region or "connects_to" in location_or_region:
+    if location_or_region.get("is_region", False) or "starting" in location_or_region or "connects_to" in location_or_region:
         object_type = "region"
-        object_name = location_or_region['region_name']
-    elif "name" in location_or_region or "region" in location_or_region:
+    elif "region" in location_or_region or "category" in location_or_region:
         object_type = "location"
 
     if source == LogicErrorSource.INFIX_TO_POSTFIX:
@@ -297,7 +296,8 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
         locationRegion = regionMap[location["region"]] if "region" in location else None
 
         if locationRegion:
-            locationRegion['region_name'] = location['region']
+            locationRegion['name'] = location['region']
+            locationRegion['is_region'] = True
 
         if "requires" in location: # Location has requires, check them alongside the region requires
             def checkBothLocationAndRegion(state: CollectionState, location=location, region=locationRegion):

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -1,7 +1,9 @@
 from typing import TYPE_CHECKING, Optional
+from enum import IntEnum
 from worlds.generic.Rules import set_rule, add_rule
 from .Regions import regionMap
 from .hooks import Rules
+
 from BaseClasses import MultiWorld, CollectionState
 from .Helpers import clamp, is_item_enabled, get_items_with_value, is_option_enabled
 from worlds.AutoWorld import World
@@ -14,9 +16,34 @@ import logging
 if TYPE_CHECKING:
     from . import ManualWorld
 
+class LogicErrorSource(IntEnum):
+    INFIX_TO_POSTFIX = 1 # includes more closing parentheses than opening (but not the opposite)
+    EVALUATE_POSTFIX = 2 # includes missing pipes and missing value on either side of AND/OR
+    EVALUATE_STACK_SIZE = 3 # includes missing curly brackets
+
+def raise_logic_error(location_or_region: dict, source: LogicErrorSource):
+    object_type = "location/region"
+    object_name = location_or_region.get("name", "Unknown")
+
+    if "region_name" in location_or_region or "starting" in location_or_region or "connects_to" in location_or_region:
+        object_type = "region"
+        object_name = location_or_region['region_name']
+    elif "name" in location_or_region or "region" in location_or_region:
+        object_type = "location"
+
+    if source == LogicErrorSource.INFIX_TO_POSTFIX:
+        source_text = "There may be mismatched parentheses, or other invalid syntax for the requires."
+    elif source == LogicErrorSource.EVALUATE_POSTFIX:
+        source_text = "There may be missing || around item names, or an AND/OR that is missing a value on one side, or other invalid syntax for the requires."
+    elif source == LogicErrorSource.EVALUATE_STACK_SIZE:
+        source_text = "There may be missing {} around requirement functions like YamlEnabled() / YamlDisabled(), or other invalid syntax for the requires." 
+    else:
+        source_text = "This requires includes invalid syntax."
+
+    raise KeyError(f"Invalid 'requires' for {object_type} '{object_name}': {source_text} (ERROR {source})")
+
 def infix_to_postfix(expr, location):
     prec = {"&": 2, "|": 2, "!": 3}
-
     stack = []
     postfix = ""
 
@@ -34,15 +61,18 @@ def infix_to_postfix(expr, location):
                 while stack and stack[-1] != "(":
                     postfix += stack.pop()
                 stack.pop()
+
         while stack:
             postfix += stack.pop()
     except Exception:
-        raise KeyError("Invalid logic format for location/region {}.".format(location))
+        raise_logic_error(location, LogicErrorSource.INFIX_TO_POSTFIX)
+
     return postfix
 
 
 def evaluate_postfix(expr: str, location: str) -> bool:
     stack = []
+
     try:
         for c in expr:
             if c == "0":
@@ -61,10 +91,11 @@ def evaluate_postfix(expr: str, location: str) -> bool:
                 op = stack.pop()
                 stack.append(not op)
     except Exception:
-        raise KeyError("Invalid logic format for location/region {}.".format(location))
+        raise_logic_error(location, LogicErrorSource.EVALUATE_POSTFIX)
 
     if len(stack) != 1:
-        raise KeyError("Invalid logic format for location/region {}.".format(location))
+        raise_logic_error(location, LogicErrorSource.EVALUATE_STACK_SIZE)
+
     return stack.pop()
 
 def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
@@ -264,6 +295,9 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
         locFromWorld = multiworld.get_location(location["name"], player)
 
         locationRegion = regionMap[location["region"]] if "region" in location else None
+
+        if locationRegion:
+            locationRegion['region_name'] = location['region']
 
         if "requires" in location: # Location has requires, check them alongside the region requires
             def checkBothLocationAndRegion(state: CollectionState, location=location, region=locationRegion):


### PR DESCRIPTION
Currently, this error is somewhat vague (should just say "requires", not "logic") and can be triggered from different areas for different reasons. Since this support question comes up decently often (twice today even, haha), wanted to clean this up.

This PR moves the KeyError up and identifies where the error came from. Then, based on that, we can offer some potential solutions to the error.

Also, better identifies whether the object passed into the error is a location or a region, and actually gives the region name if a region. (It didn't before this PR.)

(I wasn't sure if it was okay to use "enum" until I saw BaseClasses was. So using it :smile: )