### PR TITLE
After options defined use dataclass

### DIFF
--- a/src/Options.py
+++ b/src/Options.py
@@ -241,5 +241,5 @@ def make_options_group() -> list[OptionGroup]:
 
     return after_option_groups_created(option_groups)
 
-manual_options = after_options_defined(manual_options)
 manual_options_data = make_dataclass('ManualOptionsClass', manual_options.items(), bases=(PerGameCommonOptions,))
+after_options_defined(manual_options_data)

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -49,24 +49,9 @@ def after_options_defined(options: PerGameCommonOptions):
     # For example if you want to change DLC_enabled's display name you would do:
     # options.__annotations__["DLC_enabled"].display_name = "New Display Name"
 
-    # The generated goal option will not keep your defined values or documentation string you'll need to add them here:
-    # To automatically convert your own goal to alias of the generated goal uncomment the lines below and replace 'Goal' with your own option of type Choice
-
-    # your_goal_class = Goal #Your Goal class here
-    # generated_goal = options.__annotations__.get('goal', {})
-    # if generated_goal and not issubclass(generated_goal, your_goal_class): #if it exist and not the exact same
-    #     values = { **your_goal_class.options, **your_goal_class.aliases } #group your option and alias to be converted
-    #     for alias, value in values.items():
-    #         generated_goal.aliases[alias] = value
-    #     generated_goal.options.update(generated_goal.aliases)  #for an alias to be valid it must also be in options
-    #
-    #     if hasattr(your_goal_class, "default"):
-    #         generated_goal.default = your_goal_class.default
-    #
-    #     if hasattr(your_goal_class, "display_name"):
-    #         generated_goal.display_name = your_goal_class.display_name
-    #
-    #     generated_goal.__doc__ = your_goal_class.__doc__ or generated_goal.__doc__
+    #  Here's an example on how to add your aliases to the generated goal
+    # options.__annotations__['goal'].aliases.update(Goal.aliases)
+    # options.__annotations__['goal'].options.update(Goal.aliases)  #for an alias to be valid it must also be in options
 
     pass
 

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -37,10 +37,10 @@ def before_options_defined(options: dict) -> dict:
     return options
 
 # This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options
-def after_options_defined(options: PerGameCommonOptions):
-    # To access a modifiable version of options check the dict in options.__annotations__
+def after_options_defined(options: Type[PerGameCommonOptions]):
+    # To access a modifiable version of options check the dict in options.type_hints
     # For example if you want to change DLC_enabled's display name you would do:
-    # options.__annotations__["DLC_enabled"].display_name = "New Display Name"
+    # options.type_hints["DLC_enabled"].display_name = "New Display Name"
 
     #  Here's an example on how to add your aliases to the generated goal
     # options.__annotations__['goal'].aliases.update({"example": 0, "second_alias": 1})

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -1,6 +1,5 @@
 # Object classes from AP that represent different types of options that you can create
-from Options import Option, FreeText, NumericOption, Toggle, DefaultOnToggle, Choice, TextChoice, Range, NamedRange, OptionGroup
-
+from Options import Option, FreeText, NumericOption, Toggle, DefaultOnToggle, Choice, TextChoice, Range, NamedRange, OptionGroup, PerGameCommonOptions
 # These helper methods allow you to determine if an option has been set, or what its value is, for any player in the multiworld
 from ..Helpers import is_option_enabled, get_option_value
 
@@ -39,22 +38,25 @@ def before_options_defined(options: dict) -> dict:
     return options
 
 # This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options
-def after_options_defined(options: dict) -> dict:
+def after_options_defined(options: PerGameCommonOptions):
+    # To access a modifiable version of options check the dict in options.__annotations__
+
     # The generated goal option will not keep your defined values or documentation string you'll need to add them here:
     # To automatically convert your own goal to alias of the generated goal uncomment the lines below and replace 'Goal' with your own option of type Choice
 
     # your_goal_class = Goal #Your Goal class here
-    # generated_goal = options.get('goal', {})
+    # generated_goal = options.__annotations__.get('goal', {})
     # if generated_goal and issubclass(your_goal_class, Choice) and not issubclass(generated_goal, your_goal_class):
-    #     goals = {'option_' + i: v for i, v in generated_goal.options.items() if i != 'default'}
-    #     for option, value in your_goal_class.options.items():
-    #         if option == 'default':
-    #             continue
-    #         goals[f"alias_{option}"] = value
-    #     options['goal'] = type('goal', (Choice,), goals)
-    #     options['goal'].default = your_goal_class.options.get('default', generated_goal.default)
-    #     options['goal'].__doc__ = your_goal_class.__doc__ or options['goal'].__doc__
-    return options
+    #     values = {**your_goal_class.options, **your_goal_class.aliases}
+    #     for option, value in values.items():
+    #         generated_goal.aliases[f"{option}"] = value
+    #     generated_goal.options.update(generated_goal.aliases) #for an alias to be valid it must be in both
+    #     if hasattr(your_goal_class, 'default'):
+    #         generated_goal.default = your_goal_class.default
+    #     if hasattr(your_goal_class, 'display_name'):
+    #         generated_goal.display_name = your_goal_class.display_name
+    #     generated_goal.__doc__ = your_goal_class.__doc__ or options['goal'].__doc__
+    pass
 
 # Use this Hook if you want to add your Option to an Option group (existing or not)
 def before_option_groups_created(groups: dict[str, list[Option]]) -> dict[str, list[Option]]:

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -46,6 +46,8 @@ def before_options_defined(options: dict) -> dict:
 # This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options
 def after_options_defined(options: PerGameCommonOptions):
     # To access a modifiable version of options check the dict in options.__annotations__
+    # For example if you want to change DLC_enabled's display name you would do:
+    # options.__annotations__["DLC_enabled"].display_name = "New Display Name"
 
     # The generated goal option will not keep your defined values or documentation string you'll need to add them here:
     # To automatically convert your own goal to alias of the generated goal uncomment the lines below and replace 'Goal' with your own option of type Choice

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -2,7 +2,7 @@
 from Options import Option, FreeText, NumericOption, Toggle, DefaultOnToggle, Choice, TextChoice, Range, NamedRange, OptionGroup, PerGameCommonOptions
 # These helper methods allow you to determine if an option has been set, or what its value is, for any player in the multiworld
 from ..Helpers import is_option_enabled, get_option_value
-
+from typing import Type
 
 
 ####################################################################
@@ -43,8 +43,8 @@ def after_options_defined(options: Type[PerGameCommonOptions]):
     # options.type_hints["DLC_enabled"].display_name = "New Display Name"
 
     #  Here's an example on how to add your aliases to the generated goal
-    # options.__annotations__['goal'].aliases.update({"example": 0, "second_alias": 1})
-    # options.__annotations__['goal'].options.update({"example": 0, "second_alias": 1})  #for an alias to be valid it must also be in options
+    # options.type_hints['goal'].aliases.update({"example": 0, "second_alias": 1})
+    # options.type_hints['goal'].options.update({"example": 0, "second_alias": 1})  #for an alias to be valid it must also be in options
 
     pass
 

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -32,13 +32,6 @@ class TotalCharactersToWinWith(Range):
     range_end = 50
     default = 50
 
-class Goal(Choice): #Don't add this in before_options_defined as "goal" or you will get a warning in the console if you have multiple victory locations
-    """Example to convert"""
-    option_test = 0
-    option_b = 1
-    alias_c = 1
-    default = 1
-
 # This is called before any manual options are defined, in case you want to define your own with a clean slate or let Manual define over them
 def before_options_defined(options: dict) -> dict:
     return options
@@ -50,8 +43,8 @@ def after_options_defined(options: PerGameCommonOptions):
     # options.__annotations__["DLC_enabled"].display_name = "New Display Name"
 
     #  Here's an example on how to add your aliases to the generated goal
-    # options.__annotations__['goal'].aliases.update(Goal.aliases)
-    # options.__annotations__['goal'].options.update(Goal.aliases)  #for an alias to be valid it must also be in options
+    # options.__annotations__['goal'].aliases.update({"example": 0, "second_alias": 1})
+    # options.__annotations__['goal'].options.update({"example": 0, "second_alias": 1})  #for an alias to be valid it must also be in options
 
     pass
 


### PR DESCRIPTION
As discussed on discord in the thread for pr #54 https://discord.com/channels/1097532591650910289/1311063001469812807
this make after_options_defined use the dataclass to stop dev from adding options there.