### PR TITLE
remove spaces from user's options names to avoid crashes

### DIFF
--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -68,6 +68,7 @@ def is_category_enabled(multiworld: MultiWorld, player: int, category_name: str)
 def resolve_yaml_option(multiworld: MultiWorld, player: int, data: dict) -> bool:
     if "yaml_option" in data:
         for option_name in data["yaml_option"]:
+            option_name = option_name.strip().replace(" ", "_")
             required = True
             if option_name.startswith("!"):
                 option_name = option_name[1:]

--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -68,12 +68,12 @@ def is_category_enabled(multiworld: MultiWorld, player: int, category_name: str)
 def resolve_yaml_option(multiworld: MultiWorld, player: int, data: dict) -> bool:
     if "yaml_option" in data:
         for option_name in data["yaml_option"]:
-            option_name = option_name.strip().replace(" ", "_")
             required = True
             if option_name.startswith("!"):
                 option_name = option_name[1:]
                 required = False
 
+            option_name = format_to_valid_identifier(option_name)
             if is_option_enabled(multiworld, player, option_name) != required:
                 return False
     return True
@@ -206,3 +206,10 @@ def convert_to_long_string(input: str | list[str]) -> str:
     if not isinstance(input, str):
         return str.join("\n    ", input)
     return input
+
+def format_to_valid_identifier(input: str) -> str:
+    """Make sure the input is a valid python identifier"""
+    input = input.strip()
+    if input[:1].isdigit():
+        input = "_" + input
+    return input.replace(" ", "_")

--- a/src/Options.py
+++ b/src/Options.py
@@ -2,7 +2,7 @@ from Options import PerGameCommonOptions, FreeText, Toggle, DefaultOnToggle, Cho
     OptionGroup, StartInventoryPool, Visibility, item_and_loc_options, Option
 from .hooks.Options import before_options_defined, after_options_defined, before_option_groups_created, after_option_groups_created
 from .Data import category_table, game_table, option_table
-from .Helpers import convert_to_long_string
+from .Helpers import convert_to_long_string, format_to_valid_identifier
 from .Locations import victory_names
 from .Items import item_table
 from .Game import starting_items
@@ -83,9 +83,9 @@ if game_table.get("death_link"):
 ######################
 
 for option_name, option in option_table.get('core', {}).items():
-    option_name = option_name.strip().replace(" ", "_")
     if option_name.startswith('_'): #To allow commenting out options
         continue
+    option_name = format_to_valid_identifier(option_name)
 
     if manual_options.get(option_name):
         original_option: Option = manual_options[option_name]
@@ -145,10 +145,9 @@ for option_name, option in option_table.get('core', {}).items():
 
 supported_option_types = ["Toggle", "Choice", "Range"]
 for option_name, option in option_table.get('user', {}).items():
-    option_name = option_name.strip().replace(" ", "_")
     if option_name.startswith('_'): #To allow commenting out options
         continue
-
+    option_name = format_to_valid_identifier(option_name)
     if manual_options.get(option_name):
         logging.warning(f"Manual: An option with the name '{option_name}' cannot be added since it already exists in Manual Core Options. \nTo modify an existing option move it to the 'core' section of Option.json")
 
@@ -199,9 +198,9 @@ for option_name, option in option_table.get('user', {}).items():
 
 for category in category_table:
     for option_name in category_table[category].get("yaml_option", []):
-        option_name = option_name.strip().replace(" ", "_")
         if option_name[0] == "!":
             option_name = option_name[1:]
+        option_name = format_to_valid_identifier(option_name)
         if option_name not in manual_options:
             manual_options[option_name] = type(option_name, (DefaultOnToggle,), {"default": True})
             manual_options[option_name].__doc__ = "Should items/locations linked to this option be enabled?"
@@ -210,9 +209,9 @@ if starting_items:
     for starting_items in starting_items:
         if starting_items.get("yaml_option"):
             for option_name in starting_items["yaml_option"]:
-                option_name = option_name.strip().replace(" ", "_")
                 if option_name[0] == "!":
                     option_name = option_name[1:]
+                option_name = format_to_valid_identifier(option_name)
                 if option_name not in manual_options:
                     manual_options[option_name] = type(option_name, (DefaultOnToggle,), {"default": True})
                     manual_options[option_name].__doc__ = "Should items/locations linked to this option be enabled?"

--- a/src/Options.py
+++ b/src/Options.py
@@ -85,6 +85,7 @@ if game_table.get("death_link"):
 for option_name, option in option_table.get('core', {}).items():
     if option_name.startswith('_'): #To allow commenting out options
         continue
+    option_display_name = option_name
     option_name = format_to_valid_identifier(option_name)
 
     if manual_options.get(option_name):
@@ -98,18 +99,18 @@ for option_name, option in option_table.get('core', {}).items():
                 if original_option.__base__ != option_type: #only recreate if needed
                     args = getOriginalOptionArguments(original_option)
                     manual_options[option_name] = type(option_name, (option_type,), dict(args))
-                    logging.debug(f"Manual: Option.json converted option '{option_name}' into a {option_type}")
+                    logging.debug(f"Manual: Option.json converted option '{option_display_name}' into a {option_type}")
 
         elif issubclass(original_option, Choice):
             if option.get("values"):
-                raise Exception(f"You cannot modify the values of the '{option_name}' option since they cannot have their value changed by Option.json")
+                raise Exception(f"You cannot modify the values of the '{option_display_name}' option since they cannot have their value changed by Option.json")
 
             if option.get('aliases'):
                 for alias, value in option['aliases'].items():
                     original_option.aliases[alias] = value
                 original_option.options.update(original_option.aliases)  #for an alias to be valid it must also be in options
 
-                logging.debug(f"Manual: Option.json modified option '{option_name}''s aliases")
+                logging.debug(f"Manual: Option.json modified option '{option_display_name}''s aliases")
 
         elif issubclass(original_option, Range):
             if option.get('values'): #let user add named values
@@ -123,10 +124,13 @@ for option_name, option in option_table.get('core', {}).items():
                 args['special_range_names'] = {**args['special_range_names'], **{l.lower(): v for l, v in option['values'].items()}}
 
                 manual_options[option_name] = type(option_name, (NamedRange,), dict(args))
-                logging.debug(f"Manual: Option.json converted option '{option_name}' into a {NamedRange}")
+                logging.debug(f"Manual: Option.json converted option '{option_display_name}' into a {NamedRange}")
 
         if option.get('display_name'):
             manual_options[option_name].display_name = option['display_name']
+
+        elif option_name != option_display_name:
+            manual_options[option_name].display_name = option_display_name
 
         manual_options[option_name].__doc__ = convert_to_long_string(option.get('description', original_doc))
         if option.get('rich_text_doc'):
@@ -140,24 +144,25 @@ for option_name, option in option_table.get('core', {}).items():
         elif option.get('visibility'):
             manual_options[option_name].visibility = convertOptionVisibility(option['visibility'])
     else:
-        logging.debug(f"Manual: Option.json just tried to modify the option '{option_name}' but it doesn't currently exists")
+        logging.debug(f"Manual: Option.json just tried to modify the option '{option_display_name}' but it doesn't currently exists")
 
 
 supported_option_types = ["Toggle", "Choice", "Range"]
 for option_name, option in option_table.get('user', {}).items():
     if option_name.startswith('_'): #To allow commenting out options
         continue
+    option_display_name =  option_name
     option_name = format_to_valid_identifier(option_name)
     if manual_options.get(option_name):
-        logging.warning(f"Manual: An option with the name '{option_name}' cannot be added since it already exists in Manual Core Options. \nTo modify an existing option move it to the 'core' section of Option.json")
+        logging.warning(f"Manual: An option with the name '{option_display_name}' cannot be added since it already exists in Manual Core Options. \nTo modify an existing option move it to the 'core' section of Option.json")
 
     else:
         option_type = option.get('type', "").title()
 
         if option_type not in supported_option_types:
-            raise Exception(f'Option {option_name} in options.json has an invalid type of "{option["type"]}".\nIt must be one of the folowing: {supported_option_types}')
+            raise Exception(f'Option {option_display_name} in options.json has an invalid type of "{option["type"]}".\nIt must be one of the folowing: {supported_option_types}')
 
-        args = {'display_name': option.get('display_name', option_name)}
+        args = {'display_name': option.get('display_name', option_display_name)}
 
         if option_type == "Toggle":
             value = option.get('default', False)

--- a/src/Options.py
+++ b/src/Options.py
@@ -83,6 +83,7 @@ if game_table.get("death_link"):
 ######################
 
 for option_name, option in option_table.get('core', {}).items():
+    option_name = option_name.strip().replace(" ", "_")
     if option_name.startswith('_'): #To allow commenting out options
         continue
 
@@ -144,6 +145,7 @@ for option_name, option in option_table.get('core', {}).items():
 
 supported_option_types = ["Toggle", "Choice", "Range"]
 for option_name, option in option_table.get('user', {}).items():
+    option_name = option_name.strip().replace(" ", "_")
     if option_name.startswith('_'): #To allow commenting out options
         continue
 
@@ -197,6 +199,7 @@ for option_name, option in option_table.get('user', {}).items():
 
 for category in category_table:
     for option_name in category_table[category].get("yaml_option", []):
+        option_name = option_name.strip().replace(" ", "_")
         if option_name[0] == "!":
             option_name = option_name[1:]
         if option_name not in manual_options:
@@ -207,6 +210,7 @@ if starting_items:
     for starting_items in starting_items:
         if starting_items.get("yaml_option"):
             for option_name in starting_items["yaml_option"]:
+                option_name = option_name.strip().replace(" ", "_")
                 if option_name[0] == "!":
                     option_name = option_name[1:]
                 if option_name not in manual_options:


### PR DESCRIPTION
Small change that make sure options added by users are compatible with python
by removing spaces in option names
Without this, spaces create some hard to understand, for non-python users, error
like this one bennydreamly got today on discord [here](https://discord.com/channels/1097532591650910289/1097891385190928504/1316918800947613696)

