### PR TITLE
Client: Fix bug that puts Victory in `(No Category)` when it has categories

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -520,7 +520,7 @@ class ManualContext(SuperContext):
                     if category not in self.listed_locations:
                         self.listed_locations[category] = []
                 
-                if len(victory_categories) == 0:
+                if not victory_categories:
                     victory_categories.add("(No Category)")
 
                 for category in self.listed_locations:

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -511,18 +511,16 @@ class ManualContext(SuperContext):
                         self.listed_locations["(No Category)"].append(location_id)
 
                 victory_location =  self.ctx.goal_location
-                victory_categories = set()
+                victory_categories = set(victory_location.get("category", []))
 
-                if "category" in victory_location and len(victory_location["category"]) > 0:
-                    for category in victory_location["category"]:
-                        if category not in self.location_categories:
-                            self.location_categories.append(category)
+                for category in victory_categories:
+                    if category not in self.location_categories:
+                        self.location_categories.append(category)
 
-                        if category not in self.listed_locations:
-                            self.listed_locations[category] = []
-                            victory_categories.add(category)
-
-                if not victory_categories:
+                    if category not in self.listed_locations:
+                        self.listed_locations[category] = []
+                
+                if len(victory_categories) == 0:
                     victory_categories.add("(No Category)")
 
                 for category in self.listed_locations:
@@ -556,8 +554,8 @@ class ManualContext(SuperContext):
                 for location_category in sorted(self.listed_locations.keys()):
                     locations_in_category = len(self.listed_locations[location_category])
 
-                    if ("category" in victory_location and location_category in victory_location["category"]) or \
-                        ("category" not in victory_location and location_category == "(No Category)"):
+                    if (location_category in victory_categories) or \
+                        (len(victory_categories) == 0 and location_category == "(No Category)"):
                         locations_in_category += 1
 
                     category_tree = locations_panel.add_node(

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -555,7 +555,7 @@ class ManualContext(SuperContext):
                     locations_in_category = len(self.listed_locations[location_category])
 
                     if (location_category in victory_categories) or \
-                        (len(victory_categories) == 0 and location_category == "(No Category)"):
+                        (not victory_categories and location_category == "(No Category)"):
                         locations_in_category += 1
 
                     category_tree = locations_panel.add_node(

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -460,7 +460,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_11_22 # YYYYMMDD
+    version = 2024_12_13 # YYYYMMDD
     found = False
 
     if "manual" not in icon_paths:


### PR DESCRIPTION
There was an oversight in the way that victory categories are determined that appeared to only say that the victory location had categories if at least one of the categories it had was not shared by any other location.

This PR changes that behavior to instead use the categories that the victory location had defined. This also allows the Victory location button to show up in multiple categories now, and also prevents it from showing up in `(No Category)` when it has categories.