### PR TITLE
Req function argument convert rewrite

### DIFF
--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -242,10 +242,9 @@ def convert_string_to_type(input: str, target_type: type) -> any:
     found_types = []
     checktype(target_type, found_types)
 
-    original_input_type_requested = False
     if str in found_types: #do it last
         found_types.remove(str)
-        original_input_type_requested = True
+        found_types.append(str)
 
     value = input.strip()
     i = 0
@@ -288,9 +287,6 @@ def convert_string_to_type(input: str, target_type: type) -> any:
             except Exception as e:
                 errors.append(str(value_type) + ": " + str(e))
                 continue
-
-    if original_input_type_requested:
-        return input
 
     newline = "\n"
     raise Exception(f"'{value}' could not be converted to {target_type}, here's the conversion failure message(s):\n\n{newline.join([' - ' + str(validation_error) for validation_error in errors])}\n\n")

--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -241,10 +241,10 @@ def convert_string_to_type(input: str, target_type: type) -> any:
             if value.lower() == 'none':
                 return None
         elif issubclass(value_type, bool):
-            if value.lower() in ['true', '1']:
+            if value.lower() in ['true', '1', 'on']:
                 return True
 
-            elif value.lower() in ['false', '0']:
+            elif value.lower() in ['false', '0', 'off']:
                 return False
 
             else:

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -326,28 +326,28 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
 
     def convert_req_function_args(func, args: list[str], areaName: str):
         parameters = inspect.signature(func).parameters
-        knownArguments = ["world", "multiworld", "state", "player"]
+        knownParameters = ["world", "multiworld", "state", "player"]
         index = -1
-        for parameter, info in parameters.items():
-            if parameter in knownArguments:
+        for parameter in parameters.values():
+            if parameter.name in knownParameters:
                 continue
             index += 1
-            target_type = info.annotation
+            target_type = parameter.annotation
 
             if index < len(args) and args[index].strip() != "":
                 value = args[index].strip()
             else:
-                if info.default is not inspect.Parameter.empty:
+                if parameter.default is not inspect.Parameter.empty:
                     if index < len(args):
-                        args[index] = info.default
+                        args[index] = parameter.default
                     continue
                 else:
-                    if info.annotation is inspect.Parameter.empty:
-                        raise Exception(f"A call of the \"{func.__name__}\" function in \"{areaName}\"'s requirement, asks for a value for its argument \"{info.name}\" but it's missing.")
+                    if parameter.annotation is inspect.Parameter.empty:
+                        raise Exception(f"A call of the \"{func.__name__}\" function in \"{areaName}\"'s requirement, asks for a value for its argument \"{parameter.name}\" but it's missing.")
                     else:
-                        raise Exception(f"A call of the \"{func.__name__}\" function in \"{areaName}\"'s requirement, asks for a value of type {target_type} for its argument \"{info.name}\" but it's missing.")
+                        raise Exception(f"A call of the \"{func.__name__}\" function in \"{areaName}\"'s requirement, asks for a value of type {target_type} for its argument \"{parameter.name}\" but it's missing.")
 
-            if target_type == str or info.annotation is inspect.Parameter.empty: #Don't convert since its already a string or if we don't know the type to convert to
+            if target_type == str or parameter.annotation is inspect.Parameter.empty: #Don't convert since its already a string or if we don't know the type to convert to
                 args[index] = value
                 continue
 
@@ -355,7 +355,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
                 value = convert_string_to_type(value, target_type)
 
             except Exception as e:
-                raise Exception(f"A call of the \"{func.__name__}\" function in \"{areaName}\"'s requirement, asks for a value of type {target_type}\nfor its argument \"{info.name}\" but its value \"{value}\" cannot be converted to {target_type} \nOriginal Error:'{e}'")
+                raise Exception(f"A call of the \"{func.__name__}\" function in \"{areaName}\"'s requirement, asks for a value of type {target_type}\nfor its argument \"{parameter.name}\" but its value \"{value}\" cannot be converted to {target_type} \nOriginal Error:'{e}'")
 
             args[index] = value
 

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -334,7 +334,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
 
             target_type = info.annotation
 
-            if issubclass(type(target_type), type(str)): #Don't convert since its already a string
+            if target_type == str or info is inspect.Parameter.empty: #Don't convert since its already a string and if we don't know the type to convert to
                 continue
 
             if index < len(args):

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -334,7 +334,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
             index += 1
             target_type = parameter.annotation
 
-            if index < len(args) and args[index].strip() != "":
+            if index < len(args) and args[index] != "":
                 value = args[index].strip()
             else:
                 if parameter.default is not inspect.Parameter.empty:

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -5,7 +5,7 @@ from .Regions import regionMap
 from .hooks import Rules
 
 from BaseClasses import MultiWorld, CollectionState
-from .Helpers import clamp, is_item_enabled, get_items_with_value, is_option_enabled
+from .Helpers import clamp, is_item_enabled, get_items_with_value, is_option_enabled, get_option_value, convert_string_to_type
 from worlds.AutoWorld import World
 
 import re
@@ -324,7 +324,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
     # Victory requirement
     multiworld.completion_condition[player] = lambda state: state.has("__Victory__", player)
 
-    def convert_req_function_args(func, args: list[str], areaName: str, warn: bool = False):
+    def convert_req_function_args(func, args: list[str], areaName: str):
         parameters = inspect.signature(func).parameters
         knownArguments = ["world", "multiworld", "state", "player"]
         index = 0
@@ -332,66 +332,27 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
             if parameter in knownArguments:
                 continue
 
-            argType = info.annotation
-            optional = False
-            try:
-                if issubclass(argType, inspect._empty): #if not set then it wont get converted but still be checked for valid data at index
-                    argType = str
+            target_type = info.annotation
 
-            except TypeError: # Optional
-                if argType.__module__ == 'typing' and argType._name == 'Optional':
-                    optional = True
-                    argType = argType.__args__[0]
-                else:
-                    #Implementing complex typing is not simple so ill skip it for now
-                    index += 1
-                    continue
+            if issubclass(type(target_type), type(str)): #Don't convert since its already a string
+                continue
 
-            try:
-                value = args[index].strip()
-
-            except IndexError:
+            if index < len(args):
+                value = args[index]
+            else:
                 if info is not inspect.Parameter.empty:
                     value = info.default
-
-                else:
-                    raise Exception(f"A call of the {func.__name__} function in '{areaName}'s requirement, asks for a value of type {argType}\nfor its argument '{info.name}' but its missing")
-
-            if optional:
-                if isinstance(value, type(None)):
-                    index += 1
                     continue
-                elif isinstance(value, str):
-                    if value.lower() == 'none':
-                        value = None
-                        args[index] = value
-                        index += 1
-                        continue
-
-
-            if not isinstance(value, argType):
-                if issubclass(argType, bool):
-                    #Special conversion to bool
-                    if value.lower() in ['true', '1']:
-                        value = True
-
-                    elif value.lower() in ['false', '0']:
-                        value = False
-
-                    else:
-                        value = bool(value)
-                        if warn:
-                        # warning here spam the console if called from rules.py, might be worth to make it a data validation instead
-                            logging.warning(f"A call of the {func.__name__} function in '{areaName}'s requirement, asks for a value of type {argType}\nfor its argument '{info.name}' but an unknown string was passed and thus converted to {value}")
-
                 else:
-                    try:
-                        value = argType(value)
+                    raise Exception(f"A call of the {func.__name__} function in '{areaName}'s requirement, asks for a value of type {target_type}\nfor its argument '{info.name}' but its missing")
 
-                    except ValueError:
-                        raise Exception(f"A call of the {func.__name__} function in '{areaName}'s requirement, asks for a value of type {argType}\nfor its argument '{info.name}' but its value '{value}' cannot be converted to {argType}")
+            try:
+                value = convert_string_to_type(value, target_type)
 
-                args[index] = value
+            except Exception as e:
+                raise Exception(f"A call of the {func.__name__} function in '{areaName}'s requirement, asks for a value of type {target_type}\nfor its argument '{info.name}' but its value '{value}' cannot be converted to {target_type} \nOriginal Error:'{e}'")
+
+            args[index] = value
 
             index += 1
 


### PR DESCRIPTION
its the old #65 but better (hopefully)
it now can convert even weird types like: 
```python
tmp = convert_string_to_type("['test','test2']", Optional[list[str]|str|Union[int, None]] )
# tmp -> ["test","test2"]
```
also to avoid line ending issues after this I set my git to autocrlf = true and thus converted helpers back to crlf (hopefully it works this time)

I got a require function called YamlValueCompare that will use this ready.
compare with what and how you might ask? you'll see after this merge probably (don't delete the branch plz)