### PR TITLE
Support number-as-string values in Item.Count

### DIFF
--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -37,7 +37,8 @@
                 },
                 "count": {
                     "description": "(Optional) Total number of this item that will be in the itempool for randomization.",
-                    "type": "integer",
+                    "type": ["string", "integer"],
+                    "pattern": "^[0-9]+$",
                     "default": 1
                 },
                 "value": {


### PR DESCRIPTION
We allow people to have `"count": "1"` in their json.  This updates the schema to support that.