### PR TITLE
Yaml option expansion

### DIFF
--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -71,16 +71,16 @@ def resolve_yaml_option(multiworld: MultiWorld, player: int, data: dict) -> bool
             eval_f = lambda x: x.value
             if "<" in option_name:
                 option_name, target = option_name.split("<")
-                eval_f = lambda x: x < int(target)
+                eval_f = lambda x: x.value < int(target)
             elif ">" in option_name:
                 option_name, target = option_name.split(">")
-                eval_f = lambda x: x > int(target)
+                eval_f = lambda x: x.value > int(target)
             elif "=" in option_name:
                 option_name, target = option_name.split("=")
-                eval_f = lambda x: x == int(target)
+                eval_f = lambda x: x.value == int(target)
             elif ":" in option_name:
                 option_name, target = option_name.split(":")
-                eval_f = lambda x: x == target
+                eval_f = lambda x: x.current_key == target
             if option_name.startswith("!"):
                 option_name = option_name[1:]
                 eval_f = lambda x: not eval_f(x)


### PR DESCRIPTION
Still needs cleanup so I'm leaving this as draft for now.

What does this PR do?

- Allows items and locations to individually have `yaml_option` definitions
- Adds syntax to allow `yaml_option` to check range & choice options:
  - `"option>10"`, `"option<10"`, `"option=10"` and `"!option=10"` all properly check against a range option
  - `"option:choice" properly checks against a choice option