### PR TITLE
Better req function exception messages

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -1,12 +1,13 @@
 from typing import TYPE_CHECKING, Optional
 from enum import IntEnum
-from worlds.generic.Rules import set_rule, add_rule
+
 from .Regions import regionMap
 from .hooks import Rules
+from .Helpers import clamp, is_item_enabled, get_items_with_value, is_option_enabled, get_option_value, convert_string_to_type, format_to_valid_identifier
 
 from BaseClasses import MultiWorld, CollectionState
-from .Helpers import clamp, is_item_enabled, get_items_with_value, is_option_enabled, get_option_value, convert_string_to_type
 from worlds.AutoWorld import World
+from worlds.generic.Rules import set_rule, add_rule
 
 import re
 import math
@@ -138,7 +139,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
                         try:
                             result = func(world, multiworld, state, player, *func_args)
                         except Exception as ex:
-                            raise RuntimeError(f'A call to the function "{func_name}" in the "{area_name}" {area_type}\'s requires raised an Exception. \
+                            raise RuntimeError(f'A call to the function "{func_name}" in {area_type} "{area_name}"\'s requires raised an Exception. \
                                                 \nUnless it was called by another function, it should look something like "{{{func_name}({item[1]})}}" in {area_type}s.json. \
                                                 \nFull error message: \
                                                 \n\n{type(ex).__name__}: {ex}')

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -137,11 +137,11 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
                         convert_req_function_args(func, func_args, area_name)
                         try:
                             result = func(world, multiworld, state, player, *func_args)
-                        except Exception as e:
-                            raise RuntimeError(f'A call to the function "{func_name}" in the {area_type} named "{area_name}"\'s requires raised an Exception. \
-                                                \nUnless it was called by another function, it should look something like "{{{func_name}({item[1]})}}" in {area_type}.json. \
+                        except Exception as ex:
+                            raise RuntimeError(f'A call to the function "{func_name}" in the "{area_name}" {area_type}\'s requires raised an Exception. \
+                                                \nUnless it was called by another function, it should look something like "{{{func_name}({item[1]})}}" in {area_type}s.json. \
                                                 \nFull error message: \
-                                                \n{e}')
+                                                \n\n{type(ex).__name__}: {ex}')
                         if isinstance(result, bool):
                             requires_list = requires_list.replace("{" + func_name + "(" + item[1] + ")}", "1" if result else "0")
                         else:

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -139,7 +139,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
                             result = func(world, multiworld, state, player, *func_args)
                         except Exception as e:
                             raise RuntimeError(f'A call to the function "{func_name}" in the {area_type} named "{area_name}"\'s requires raised an Exception. \
-                                                \nUnless it was called by another function, it looks like {{{func_name}({item[1]})}} in {area_type}.json. \
+                                                \nUnless it was called by another function, it should look something like "{{{func_name}({item[1]})}}" in {area_type}.json. \
                                                 \nFull error message: \
                                                 \n{e}')
                         if isinstance(result, bool):

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -134,8 +134,8 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
                         try:
                             result = func(world, multiworld, state, player, *func_args)
                         except Exception as e:
-                            raise RuntimeError(f"The function `{func_name}` in the {'region' if area.get("is_region",False) else 'location'} named \"{area.get("name", f"with these parameters: {area}")}\"'s requires raised an Exception. \
-                                                \nUnless it was called by another function, in {'region' if area.get("is_region",False) else 'location'}.json it looks something like {{{func_name}({', '.join(func_args)})}}. \
+                            raise RuntimeError(f"A call to the function `{func_name}` in the {'region' if area.get("is_region",False) else 'location'} named \"{area.get("name", f"with these parameters: {area}")}\"'s requires raised an Exception. \
+                                                \nUnless it was called by another function, it looks like {{{func_name}({item[1]})}} in {'region' if area.get("is_region",False) else 'location'}.json. \
                                                 \nFull error message: \
                                                 \n{e}")
                         if isinstance(result, bool):


### PR DESCRIPTION
while testing for my YamlCompare req rule (ill do another pr soon)
I noticed that whenever a requirement function cause an exception its not that clear where/what function caused said error unless actively debugging (which is not something most of the devs will do)
to do this I added a try except with a custom message that tell exactly in what area the function was called.
![image](https://github.com/user-attachments/assets/2079ab6e-bcdf-48d7-bc79-3415d702d19f)
before this it would jump to the green part of the image
I also changed the recusion test from >= to > so it make more sense with existing error message

I know line [143 of rules.py](https://github.com/ManualForArchipelago/Manual/pull/127/files#diff-a25c303033861df67335b2a78c209196808d8d93e059588997e9f5422bad35e8R143) look weird but in fstring the way to escape {} is to double them
like so "{{{func_name}({item[1]})}}" become this in output: {_func_name_(_item[1]_)}