### PR TITLE
Overhaul `before_create_item` hook

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -131,7 +131,7 @@ class ManualWorld(World):
 
             if item_count == 0: continue
 
-            name, item_count = before_create_item(name, item_count, self, self.multiworld, self.player)
+            name, count = before_create_item(name, count, self, self.multiworld, self.player)
 
             for _ in range(item_count):
                 new_item = self.create_item(name)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -131,8 +131,6 @@ class ManualWorld(World):
 
             if item_count == 0: continue
 
-            name, count = before_create_item(name, count, self, self.multiworld, self.player)
-
             for _ in range(item_count):
                 new_item = self.create_item(name)
                 pool.append(new_item)
@@ -212,6 +210,8 @@ class ManualWorld(World):
         self.multiworld.itempool += pool
 
     def create_item(self, name: str) -> Item:
+        name = before_create_item(name, self, self.multiworld, self.player)
+
         item = self.item_name_to_item[name]
         classification = ItemClassification.filler
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -131,6 +131,8 @@ class ManualWorld(World):
 
             if item_count == 0: continue
 
+            name, count = before_create_item(name, count, self, self.multiworld, self.player)
+
             for _ in range(item_count):
                 new_item = self.create_item(name)
                 pool.append(new_item)
@@ -210,8 +212,6 @@ class ManualWorld(World):
         self.multiworld.itempool += pool
 
     def create_item(self, name: str) -> Item:
-        name = before_create_item(name, self, self.multiworld, self.player)
-
         item = self.item_name_to_item[name]
         classification = ItemClassification.filler
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -30,7 +30,7 @@ from worlds.AutoWorld import World, WebWorld
 
 from .hooks.World import \
     hook_get_filler_item_name, before_create_regions, after_create_regions, \
-    before_create_items_starting, before_create_items_filler, after_create_items, \
+    before_create_items_all, before_create_items_starting, before_create_items_filler, after_create_items, \
     before_create_item, after_create_item, \
     before_set_rules, after_set_rules, \
     before_generate_basic, after_generate_basic, \
@@ -113,28 +113,52 @@ class ManualWorld(World):
         traps = []
         configured_item_names = self.item_id_to_name.copy()
 
+        items_config = {}
         for name in configured_item_names.values():
-            # victory gets placed via place_locked_item at the victory location in create_regions
             if name == "__Victory__": continue
-            # the game.json filler item name is added to the item lookup, so skip it until it's potentially needed later
             if name == filler_item_name: continue # intentionally using the Game.py filler_item_name here because it's a non-Items item
+            if item.get("trap"):
+                traps.append(name)
 
             item = self.item_name_to_item[name]
             item_count = int(item.get("count", 1))
-
-            if item.get("trap"):
-                traps.append(name)
 
             if "category" in item:
                 if not is_item_enabled(self.multiworld, self.player, item):
                     item_count = 0
 
-            if item_count == 0: continue
+            items_config[name] = item_count
 
-            for _ in range(item_count):
-                new_item = self.create_item(name)
-                pool.append(new_item)
+        items_config = before_create_items_all(items_config, self, self.multiworld, self.player)
 
+        for name, configs in items_config.items():
+            total_created = 0
+            if type(configs) == int:
+                total_created = configs
+                for _ in range(configs):
+                    new_item = self.create_item(name)
+                    pool.append(new_item)
+            elif type(configs) == dict:
+                for cat, count in configs.values():
+                    total_created += count
+                    true_class = {
+                        "filler": ItemClassification.filler,
+                        "trap": ItemClassification.trap,
+                        "useful": ItemClassification.useful,
+                        "progression_skip_balancing": ItemClassification.progression_skip_balancing,
+                        "progression": ItemClassification.progression
+                    }.get(cat, cat)
+                    if not isinstance(true_class, ItemClassification):
+                        raise Exception(f"Item override for {name} improperly defined")
+                    for _ in range(count):
+                        new_item = self.create_item(name, true_class)
+                        pool.append(new_item)
+            else:
+                raise Exception(f"Item override for {name} improperly defined")
+
+            if total_created == 0: continue
+
+            item = self.item_name_to_item[name]
             if item.get("early"): # Some or all early
                 if isinstance(item["early"],int) or (isinstance(item["early"],str) and item["early"].isnumeric()):
                     self.multiworld.early_items[self.player][name] = int(item["early"])
@@ -209,22 +233,25 @@ class ManualWorld(World):
         # then will remove specific item placements below from the overall pool
         self.multiworld.itempool += pool
 
-    def create_item(self, name: str) -> Item:
+    def create_item(self, name: str, class_override: Optional['ItemClassification']=None) -> Item:
         name = before_create_item(name, self, self.multiworld, self.player)
 
         item = self.item_name_to_item[name]
-        classification = ItemClassification.filler
+        if class_override is not None:
+            classification = class_override
+        else:
+            classification = ItemClassification.filler
 
-        if "trap" in item and item["trap"]:
-            classification |= ItemClassification.trap
+            if "trap" in item and item["trap"]:
+                classification |= ItemClassification.trap
 
-        if "useful" in item and item["useful"]:
-            classification |= ItemClassification.useful
+            if "useful" in item and item["useful"]:
+                classification |= ItemClassification.useful
 
-        if "progression_skip_balancing" in item and item["progression_skip_balancing"]:
-            classification |= ItemClassification.progression_skip_balancing
-        elif "progression" in item and item["progression"]:
-            classification |= ItemClassification.progression
+            if "progression_skip_balancing" in item and item["progression_skip_balancing"]:
+                classification |= ItemClassification.progression_skip_balancing
+            elif "progression" in item and item["progression"]:
+                classification |= ItemClassification.progression
 
         item_object = ManualItem(name, classification,
                         self.item_name_to_id[name], player=self.player)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -131,7 +131,7 @@ class ManualWorld(World):
 
             if item_count == 0: continue
 
-            name, count = before_create_item(name, count, self, self.multiworld, self.player)
+            name, item_count = before_create_item(name, item_count, self, self.multiworld, self.player)
 
             for _ in range(item_count):
                 new_item = self.create_item(name)

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -112,7 +112,7 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     # location.access_rule = lambda state: old_rule(state) or Example_Rule(state)
 
 # The item name and quantity to create is provided before the item is created, in case you want to make changes to it
-def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> tuple[str, int]:
+def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> Tuple[str, int]:
     return item_name, count
 
 # The item that was created is provided after creation, in case you want to modify the item

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -112,8 +112,8 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     # location.access_rule = lambda state: old_rule(state) or Example_Rule(state)
 
 # The item name to create is provided before the item is created, in case you want to make changes to it
-def before_create_item(item_name: str, world: World, multiworld: MultiWorld, player: int) -> str:
-    return item_name
+def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> str, int:
+    return item_name, count
 
 # The item that was created is provided after creation, in case you want to modify the item
 def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, player: int) -> ManualItem:

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -111,8 +111,8 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     # OR
     # location.access_rule = lambda state: old_rule(state) or Example_Rule(state)
 
-# The item name to create is provided before the item is created, in case you want to make changes to it
-def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> str, int:
+# The item name and quantity to create is provided before the item is created, in case you want to make changes to it
+def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> Tuple[str, int]:
     return item_name, count
 
 # The item that was created is provided after creation, in case you want to modify the item

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -112,7 +112,7 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     # location.access_rule = lambda state: old_rule(state) or Example_Rule(state)
 
 # The item name and quantity to create is provided before the item is created, in case you want to make changes to it
-def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> Tuple[str, int]:
+def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> tuple[str, int]:
     return item_name, count
 
 # The item that was created is provided after creation, in case you want to modify the item

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -112,8 +112,8 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     # location.access_rule = lambda state: old_rule(state) or Example_Rule(state)
 
 # The item name to create is provided before the item is created, in case you want to make changes to it
-def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> str, int:
-    return item_name, count
+def before_create_item(item_name: str, world: World, multiworld: MultiWorld, player: int) -> str:
+    return item_name
 
 # The item that was created is provided after creation, in case you want to modify the item
 def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, player: int) -> ManualItem:

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -111,8 +111,8 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     # OR
     # location.access_rule = lambda state: old_rule(state) or Example_Rule(state)
 
-# The item name and quantity to create is provided before the item is created, in case you want to make changes to it
-def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> Tuple[str, int]:
+# The item name to create is provided before the item is created, in case you want to make changes to it
+def before_create_item(item_name: str, count: int, world: World, multiworld: MultiWorld, player: int) -> str, int:
     return item_name, count
 
 # The item that was created is provided after creation, in case you want to modify the item

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -55,6 +55,16 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     if hasattr(multiworld, "clear_location_cache"):
         multiworld.clear_location_cache()
 
+# This hook allows you to access the item names & counts before the items are created. Use this to increase/decrease the amount of a specific item in the pool
+# Valid item_config key/values:
+# {"Item Name": 5} <- This will create qty 5 items using all the default settings
+# {"Item Name": {"useful": 7}} <- This will create qty 7 items and force them to be classified as useful
+# {"Item Name": {"progression": 2, "useful": 1}} <- This will create 3 items, with 2 classified as progression and 1 as useful
+# {"Item Name": {0b0110: 5}} <- If you know the special flag for the item classes, you can also define non-standard options. This setup
+#       will create 5 items that are the "useful trap" class
+def before_create_items_all(item_config: dict[str: int|dict], world: World, multiworld: Multiworld, player: int) -> dict[str: int|dict]:
+    return item_config
+
 # The item pool before starting items are processed, in case you want to see the raw item pool at that stage
 def before_create_items_starting(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
     return item_pool


### PR DESCRIPTION
Nobody actually uses the current `before_create_item` hook, because it only lets you edit the item's name.

This version adds the ability to change how many of an item are created, which is a significantly more stable way to manage dynamic item counts than the current process of removing them in `before_create_items_filler`

The old functionality is still maintained