### PR TITLE
Add .editorconfig to standardize encoding and whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.{py,md,json}]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,16 @@
 # top-most EditorConfig file
 root = true
 
-[*.{py,md,json}]
+[*.{py,json}]
 indent_style = space
 indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = false
 insert_final_newline = true


### PR DESCRIPTION
Similar to #129, this standardizes a few IDE settings to reduce unintended whitespace and encoding changes