### PR TITLE
Make req function generic arguments optional

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -423,7 +423,7 @@ def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, play
     return world.itemvalue_rule_cache[player][value_name]['count'] >= requested_count
 
 # Two useful functions to make require work if an item is disabled instead of making it inaccessible
-def OptOne(world: World, multiworld: MultiWorld, state: CollectionState, player: int, item: str, items_counts: Optional[dict] = None):
+def OptOne(world: World, item: str, items_counts: Optional[dict] = None):
     """Check if the passed item (with or without ||) is enabled, then this returns |item:count|
     where count is clamped to the maximum number of said item in the itempool.\n
     Eg. requires: "{OptOne(|DisabledItem|)} and |other items|" become "|DisabledItem:0| and |other items|" if the item is disabled.
@@ -481,7 +481,7 @@ def OptAll(world: World, multiworld: MultiWorld, state: CollectionState, player:
         requires_list = requires_list.replace("{" + func_name + "(" + item[1] + ")}", "{" + func_name + "(temp)}")
     # parse user written statement into list of each item
     for item in re.findall(r'\|[^|]+\|', requires):
-        itemScanned = OptOne(world, multiworld, state, player, item, items_counts)
+        itemScanned = OptOne(world, item, items_counts)
         requires_list = requires_list.replace(item, itemScanned)
 
     for function in functions:
@@ -489,16 +489,16 @@ def OptAll(world: World, multiworld: MultiWorld, state: CollectionState, player:
     return requires_list
 
 # Rule to expose the can_reach_location core function
-def canReachLocation(world: World, multiworld: MultiWorld, state: CollectionState, player: int, location: str):
+def canReachLocation(state: CollectionState, player: int, location: str):
     """Can the player reach the given location?"""
     if state.can_reach_location(location, player):
         return True
     return False
 
-def YamlEnabled(world: "ManualWorld", multiworld: MultiWorld, state: CollectionState, player: int, param: str) -> bool:
+def YamlEnabled(multiworld: MultiWorld, player: int, param: str) -> bool:
     """Is a yaml option enabled?"""
     return is_option_enabled(multiworld, player, param)
 
-def YamlDisabled(world: "ManualWorld", multiworld: MultiWorld, state: CollectionState, player: int, param: str) -> bool:
+def YamlDisabled(multiworld: MultiWorld, player: int, param: str) -> bool:
     """Is a yaml option disabled?"""
     return not is_option_enabled(multiworld, player, param)

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -361,6 +361,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
                         args[index] = parameter.default
                     else:
                         args.insert(index, parameter.default)
+                    continue
                 else:
                     if parameter.annotation is inspect.Parameter.empty:
                         raise Exception(f"A call of the \"{func.__name__}\" function in \"{areaName}\"'s requirement, asks for a value for its argument \"{parameter.name}\" but it's missing.")

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -342,15 +342,16 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
         for parameter in parameters.values():
             target_type = parameter.annotation
             index += 1
-            if target_type in knownParameters or parameter.name.lower() == "player":
+            if target_type in knownParameters:
                 if target_type in [World, 'ManualWorld']:
                     args.insert(index, world)
                 elif target_type == MultiWorld:
                     args.insert(index, multiworld)
                 elif target_type == CollectionState:
                     args.insert(index, state)
-                else:
-                    args.insert(index, player)
+                continue
+            if parameter.name.lower() == "player":
+                args.insert(index, player)
                 continue
 
             if index < len(args) and args[index] != "":

--- a/src/hooks/Rules.py
+++ b/src/hooks/Rules.py
@@ -7,7 +7,7 @@ import re
 
 # Sometimes you have a requirement that is just too messy or repetitive to write out with boolean logic.
 # Define a function here, and you can use it in a requires string with {function_name()}.
-def overfishedAnywhere(world: World, multiworld: MultiWorld, state: CollectionState, player: int):
+def overfishedAnywhere(world: World, state: CollectionState, player: int):
     """Has the player collected all fish from any fishing log?"""
     for cat, items in world.item_name_groups:
         if cat.endswith("Fishing Log") and state.has_all(items, player):
@@ -16,7 +16,7 @@ def overfishedAnywhere(world: World, multiworld: MultiWorld, state: CollectionSt
 
 # You can also pass an argument to your function, like {function_name(15)}
 # Note that all arguments are strings, so you'll need to convert them to ints if you want to do math.
-def anyClassLevel(world: World, multiworld: MultiWorld, state: CollectionState, player: int, level: str):
+def anyClassLevel(state: CollectionState, player: int, level: str):
     """Has the player reached the given level in any class?"""
     for item in ["Figher Level", "Black Belt Level", "Thief Level", "Red Mage Level", "White Mage Level", "Black Mage Level"]:
         if state.count(item, player) >= int(level):
@@ -24,6 +24,6 @@ def anyClassLevel(world: World, multiworld: MultiWorld, state: CollectionState, 
     return False
 
 # You can also return a string from your function, and it will be evaluated as a requires string.
-def requiresMelee(world: World, multiworld: MultiWorld, state: CollectionState, player: int):
+def requiresMelee():
     """Returns a requires string that checks if the player has unlocked the tank."""
     return "|Figher Level:15| or |Black Belt Level:15| or |Thief Level:15|"


### PR DESCRIPTION
this let devs make their require functions arguments in anyway they wants.
if they want to have the world all they need to do is include an argument with any name with `: World`
same for CollectionState and Multiworld.
the only reserved argument name is player
example:
```python
SurpriseMe(wld: World, mv: Multiworld, player: int)
```
is valid
as is
```python
CopyPastaRequire()
```
Even the following would work:
```python
scrambledArgs(test: str, world: World, player: int, potato: str)
```
I also removed the unused arguments of existing req rules to fit with this change.