### PR TITLE
uses explicit tab adding to not get the needless "All" tab

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -14,9 +14,6 @@ ModuleUpdate.update()
 
 import Utils
 
-if __name__ == "__main__":
-    Utils.init_logging("ManualClient", exception_logger="Client")
-
 from NetUtils import ClientStatus
 from CommonClient import gui_enabled, logger, get_base_parser, ClientCommandProcessor, server_loop
 from MultiServer import mark_raw
@@ -322,10 +319,6 @@ class ManualContext(SuperContext):
             background_color = ColorProperty()
 
         class ManualManager(ui):
-            logging_pairs = [
-                ("Client", "Archipelago"),
-                ("Manual", "Manual"),
-            ]
             base_title = "Archipelago Manual Client"
             listed_items = {"(No Category)": []}
             item_categories = ["(No Category)"]
@@ -358,11 +351,11 @@ class ManualContext(SuperContext):
 
                 self.grid.add_widget(self.manual_game_layout, 3)
 
-                for child in self.tabs.tab_list:
-                    if child.text == "Manual":
-                        panel = child # instead of creating a new TabbedPanelItem, use the one we use above to make the tabs show
+                # for child in self.tabs.tab_list:
+                #     if child.text == "Manual":
+                #         panel = child # instead of creating a new TabbedPanelItem, use the one we use above to make the tabs show
 
-                panel.content = ManualTabLayout(orientation="vertical")
+                panel = self.add_client_tab("Manual", ManualTabLayout(orientation="vertical"))
 
                 self.controls_panel = ManualControlsLayout(orientation="horizontal", size_hint_y=None, height=dp(40))
                 self.tracker_and_locations_panel = TrackerAndLocationsLayout(cols = 2)

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -351,10 +351,6 @@ class ManualContext(SuperContext):
 
                 self.grid.add_widget(self.manual_game_layout, 3)
 
-                # for child in self.tabs.tab_list:
-                #     if child.text == "Manual":
-                #         panel = child # instead of creating a new TabbedPanelItem, use the one we use above to make the tabs show
-
                 panel = self.add_client_tab("Manual", ManualTabLayout(orientation="vertical"))
 
                 self.controls_panel = ManualControlsLayout(orientation="horizontal", size_hint_y=None, height=dp(40))


### PR DESCRIPTION
to keep back compat with before 0.5.1 you can reimplement add_client_tab() https://github.com/ArchipelagoMW/Archipelago/pull/3950
but that function was created so clients wouldn't have to change when kivymd gets merged so I would suggest using it for future compat