### PR TITLE
Dev recommended item/loc sorting

### DIFF
--- a/schemas/Manual.meta.schema.json
+++ b/schemas/Manual.meta.schema.json
@@ -87,15 +87,17 @@
             "type": "boolean",
             "default": false
         },
-        "sort_items_alphabetically": {
+        "preferred_items_sorting": {
             "description": "Sort items alphabetically in the Client UI",
-            "type": "boolean",
-            "default": true
+            "type": "string",
+            "enum": ["id", "inverted_id", "alphabetical", "inverted_alphabetical"],
+            "default": "alphabetical"
         },
-        "sort_locations_alphabetically": {
+        "preferred_locations_sorting": {
             "description": "Sort locations alphabetically in the Client UI",
-            "type": "boolean",
-            "default": true
+            "type": "string",
+            "enum": ["id", "inverted_id", "alphabetical", "inverted_alphabetical"],
+            "default": "alphabetical"
         }
     },
     "definitions": {

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -102,7 +102,7 @@ class ManualClientCommandProcessor(ClientCommandProcessor):
             self.ctx.ui.request_update_tracker_and_locations_table()
             self.ctx.save_options()
             self.output(f"Set {'Items' if target_items else 'Locations'} sorting algorithm to {algorithm}")
-            if cur_sort == "recommended" and self.ctx.game is not None:
+            if algorithm == "recommended" and self.ctx.game is not None:
                 dev_sort = getattr(AutoWorldRegister.world_types[self.ctx.game], "preferred_items_sorting", SortingOrder.alphabetical).name
                 self.output(f"The recommended {'Items' if target_items else 'Locations'} sorting algorithm from the Apworld's dev is {dev_sort}.")
 

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -66,6 +66,34 @@ class ManualClientCommandProcessor(ClientCommandProcessor):
             self.output(response)
             return False
 
+    @mark_raw
+    def _cmd_items_sorting(self, sorting: str) -> bool:
+        names = [e.key for e in SortingOrder].append("recommended")
+        sorting, usable, response = Utils.get_intended_text(
+            sorting,
+            names
+        )
+        if usable:
+            self.ctx.items_sorting = sorting
+            # TODO Find how to save to settings
+        else:
+            self.output(response)
+            return False
+
+    @mark_raw
+    def _cmd_locations_sorting(self, sorting: str) -> bool:
+        names = [e.key for e in SortingOrder].append("recommended")
+        sorting, usable, response = Utils.get_intended_text(
+            sorting,
+            names
+        )
+        if usable:
+            self.ctx.locations_sorting = sorting
+
+        else:
+            self.output(response)
+            return False
+
 
 
 

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -117,6 +117,7 @@ class ManualContext(SuperContext):
     deathlink_out = False
 
     search_term = ""
+    settings = None
     items_sorting = "recommended"
     locations_sorting = "recommended"
 
@@ -170,9 +171,12 @@ class ManualContext(SuperContext):
             self.victory_names = ["__Manual Game Complete__"]
             self.goal_location = self.get_location_by_name("__Manual Game Complete__")
 
-        if world is not None and hasattr(world, "settings"):
-            self.items_sorting = world.settings.items_sorting_order
-            self.locations_sorting = world.settings.locations_sorting_order
+        self.settings = Utils.get_settings()["manual_settings"] #.get(self.game.lower(), None)
+        if self.settings is not None:
+            if hasattr(world.settings, "items_sorting_order"):
+                self.items_sorting = world.settings.items_sorting_order
+            if hasattr(world.settings, "locations_sorting_order"):
+                self.locations_sorting = world.settings.locations_sorting_order
 
         await self.get_username()
         await self.send_connect()
@@ -223,6 +227,12 @@ class ManualContext(SuperContext):
 
     def clear_search(self):
         self.search_term = ""
+
+    def save_options(self):
+        if self.settings is not None:
+            self.settings.items_sorting_order = self.items_sorting
+            self.settings.locations_sorting_order = self.locations_sorting
+            Utils.get_settings().save()
 
     @property
     def endpoints(self):

--- a/src/Meta.py
+++ b/src/Meta.py
@@ -1,5 +1,6 @@
 
 from BaseClasses import Tutorial
+from enum import Enum
 from worlds.AutoWorld import World, WebWorld
 from .Data import meta_table
 from .Helpers import convert_to_long_string
@@ -16,6 +17,12 @@ class ManualWeb(WebWorld):
         "setup/en",
         ["Fuzzy"]
     )]
+
+class SortingOrder(Enum):
+    id = 1
+    inverted_id = -1
+    alphabetical = 2
+    inverted_alphabetical = -2
 
 ######################################
 # Convert meta.json data to properties
@@ -70,5 +77,5 @@ world_webworld: ManualWeb = set_world_webworld(ManualWeb())
 
 enable_region_diagram = bool(meta_table.get("enable_region_diagram", False))
 
-sort_items_alphabetically = bool(meta_table.get("sort_items_alphabetically", True))
-sort_locations_alphabetically = bool(meta_table.get("sort_locations_alphabetically", True))
+preferred_items_sorting = SortingOrder[meta_table.get("preferred_items_sorting", "alphabetical")]
+preferred_locations_sorting = SortingOrder[meta_table.get("preferred_locations_sorting", "alphabetical")]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,8 +2,9 @@ from base64 import b64encode
 import logging
 import os
 import json
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 import webbrowser
+import settings
 
 import Utils
 from worlds.generic.Rules import forbid_items_for_player
@@ -11,7 +12,7 @@ from worlds.LauncherComponents import Component, SuffixIdentifier, components, T
 
 from .Data import item_table, location_table, region_table, category_table
 from .Game import game_name, filler_item_name, starting_items
-from .Meta import world_description, world_webworld, enable_region_diagram, sort_items_alphabetically, sort_locations_alphabetically
+from .Meta import world_description, world_webworld, enable_region_diagram, preferred_items_sorting, preferred_locations_sorting, SortingOrder
 from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups, victory_names
 from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups
 from .DataValidation import runGenerationDataValidation, runPreFillDataValidation
@@ -36,10 +37,30 @@ from .hooks.World import \
     before_extend_hint_information, after_extend_hint_information
 from .hooks.Data import hook_interpret_slot_data
 
+class ManualSettings(settings.Group):
+    class ItemsSorting(str):
+        """Set your preferred Items sorting order
+        valid options:
+        recommended: Use the sorting the dev prefer for you to use
+        id, inverted_id: Sort by item ids
+        alphabetical, inverted_alphabetical: Sort by item name
+        """
+    class LocationsSorting(str):
+        """Set your preferred Locations sorting order
+        valid options:
+        recommended: Use the sorting the dev prefer for you to use
+        id, inverted_id: Sort by location ids
+        alphabetical, inverted_alphabetical: Sort by location name
+        """
+
+    items_sorting_order: Optional[ItemsSorting] = "recommended"
+    locations_sorting_order: Optional[LocationsSorting] = "recommended"
+
 class ManualWorld(World):
     __doc__ = world_description
     game: str = game_name
     web = world_webworld
+    settings = ManualSettings
 
     options_dataclass = manual_options_data
     data_version = 2
@@ -66,8 +87,8 @@ class ManualWorld(World):
     location_name_groups = location_name_groups
     victory_names = victory_names
 
-    sort_items_alphabetically = sort_items_alphabetically
-    sort_locations_alphabetically = sort_locations_alphabetically
+    preferred_items_sorting = preferred_items_sorting
+    preferred_locations_sorting = preferred_locations_sorting
 
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@ from base64 import b64encode
 import logging
 import os
 import json
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, ClassVar
 import webbrowser
 import settings
 
@@ -53,14 +53,15 @@ class ManualSettings(settings.Group):
         alphabetical, inverted_alphabetical: Sort by location name
         """
 
-    items_sorting_order: Optional[ItemsSorting] = "recommended"
-    locations_sorting_order: Optional[LocationsSorting] = "recommended"
+    items_sorting_order: ItemsSorting = ItemsSorting("recommended")
+    locations_sorting_order: LocationsSorting = LocationsSorting("recommended")
 
 class ManualWorld(World):
     __doc__ = world_description
     game: str = game_name
     web = world_webworld
-    settings = ManualSettings
+    settings: ClassVar[ManualSettings]
+    settings_key: ClassVar[str] = "manual_settings"
 
     options_dataclass = manual_options_data
     data_version = 2


### PR DESCRIPTION
Alternate continuation of #115 
it didnt feel polite to continue on their branch/pr so I made mine and merged from theirs
if silasary wants to continue their own version of this then I can close this PR

Even if AP ClientSide is something I barely know I can work with what's already there or get inspired from other apworlds if required (minecraft fabric client was a big source of info on how to use and save settings)
## Anyway
As discusted, in #115 I let devs set their prefered sorting out of [Id, inverted_id, alphabetical, inverted_alphabetical]
why an enum and not a bool? its so later we can add more sorting methodes/algorithm
Of course I added some settings so the player can override the dev's sorting preference.
the settings get saved in the host.yaml

the one thing im not sure about that is the setting key, or in the host.yaml should every manual's setting use a single "manual_settings" key of have one for each manual
(currently going for singular but im leaving the code commented out for multiple)

Also I dont know how to make buttons so commands is what you'll get for now
If anyone wants to participate in the PR to add those or find a better way to refresh the locations on change of sorting then feel free to do so