### PR TITLE
Fix region logic to apply to entrances and not exits

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -283,7 +283,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
     for region in regionMap.keys():
         used_location_names.extend([l.name for l in multiworld.get_region(region, player).locations])
         if region != "Menu":
-            for exitRegion in multiworld.get_region(region, player).exits:
+            for exitRegion in multiworld.get_region(region, player).entrances:
                 def fullRegionCheck(state: CollectionState, region=regionMap[region]):
                     return fullLocationOrRegionCheck(state, region)
 


### PR DESCRIPTION
Region logic was applied to exits, and so `can_reach_region` was incorrectly triggering before the region requirements were found.