### PR TITLE
User facing events

### DIFF
--- a/src/Locations.py
+++ b/src/Locations.py
@@ -22,7 +22,9 @@ for key, _ in enumerate(location_table):
         else:
             raise ValueError(f"{location_table[key]['name']} has an invalid ID. ID must be at least {count + 1}")
 
-    location_table[key]["id"] = count
+    if "event" not in location_table[key]:
+        location_table[key]["id"] = count
+        count += 1
 
     if "region" not in location_table[key]:
         location_table[key]["region"] = "Manual" # all locations are in the same region for Manual
@@ -30,12 +32,10 @@ for key, _ in enumerate(location_table):
     if isinstance(location_table[key].get("category", []), str):
         location_table[key]["category"] = [location_table[key]["category"]]
 
-    count += 1
 
 if not victory_names:
     # Add the game completion location, which will have the Victory item assigned to it automatically
     location_table.append({
-        "id": count + 1,
         "name": "__Manual Game Complete__",
         "region": "Manual",
         "requires": []
@@ -48,8 +48,11 @@ location_name_to_location: dict[str, dict] = {}
 location_name_groups: dict[str, list[str]] = {}
 
 for item in location_table:
-    location_id_to_name[item["id"]] = item["name"]
     location_name_to_location[item["name"]] = item
+    if "id" not in item:
+        # events
+        continue
+    location_id_to_name[item["id"]] = item["name"]
 
     for c in item.get("category", []):
         if c not in location_name_groups:

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -12,7 +12,7 @@ from worlds import AutoWorldRegister, network_data_package
 from worlds.LauncherComponents import icon_paths
 import json
 import traceback
-
+from BaseClasses import ItemClassification
 
 import ModuleUpdate
 ModuleUpdate.update()
@@ -22,7 +22,7 @@ import Utils
 if __name__ == "__main__":
     Utils.init_logging("ManualClient", exception_logger="Client")
 
-from NetUtils import ClientStatus
+from NetUtils import ClientStatus, NetworkItem
 from CommonClient import gui_enabled, logger, get_base_parser, ClientCommandProcessor, server_loop
 from MultiServer import mark_raw
 
@@ -691,8 +691,15 @@ class ManualContext(SuperContext):
                                 self.listed_items[category_name].clear()
 
                                 # Label (for all item listings)
+                                items_and_events_recieved = list(self.ctx.items_received)
+
+                                for event in self.ctx.tracker_reachable_events:
+                                    event_item = self.ctx.get_item_by_name(item_name)
+                                    if "id" in event_item:
+                                        items_and_events_recieved.append(NetworkItem(event_item['id'], None, self.ctx.slot, ItemClassification.progression))
+
                                 sorted_items_received = sorted([
-                                    i.item for i in self.ctx.items_received
+                                    i.item for i in items_and_events_recieved
                                 ], key=self.ctx.item_names.lookup_in_game)
 
                                 for network_item in sorted_items_received:

--- a/src/Regions.py
+++ b/src/Regions.py
@@ -1,6 +1,7 @@
-from BaseClasses import Entrance, MultiWorld, Region
+from BaseClasses import Entrance, MultiWorld, Region, ItemClassification
 from .Helpers import is_category_enabled, is_location_enabled
 from .Data import region_table
+from .Items import ManualItem
 from .Locations import ManualLocation, location_name_to_location
 from worlds.AutoWorld import World
 
@@ -58,10 +59,12 @@ def create_region(world: World, multiworld: MultiWorld, player: int, name: str, 
 
     if locations:
         for location in locations:
-            loc_id = world.location_name_to_id.get(location, 0)
+            loc_id = world.location_name_to_id.get(location, None)
             locationObj = ManualLocation(player, location, loc_id, ret)
             if location_name_to_location[location].get('prehint'):
                 world.options.start_location_hints.value.add(location)
+            if location.get("event"):
+                locationObj.place_locked_item(ManualItem(name, ItemClassification.progression, None, world.player))
             ret.locations.append(locationObj)
     if exits:
         for exit in exits:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -459,7 +459,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_12_13 # YYYYMMDD
+    version = 2025_02_18 # YYYYMMDD
     found = False
 
     if "manual" not in icon_paths:


### PR DESCRIPTION
NOTE:  Very work-in-progress.

This PR lets authors make pseudo-locations and place events on them.  These are useful for logic reasons (They can be required by the generator, and should cut down on CanReach usage), but with the aid of Universal Tracker, can also place tracker items into the player's inventory, allowing for simple logic calculations without adding place_item checks that inflate the location count.

It is not done yet, validation rules will fail on non-item event requirements, and I haven't tested the UI anywhere near enough.   But pushing for the sake of sharing where it's at, since I probably won't get back to it for another week or so