### PR TITLE
Client sort order revert while we wait on client updates

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -521,7 +521,7 @@ class ManualContext(SuperContext):
                     victory_categories.add("(No Category)")
 
                 for category in self.listed_locations:
-                    self.listed_locations[category].sort(key=self.ctx.location_names.lookup_in_game)
+                    self.listed_locations[category].sort()
 
                 items_length = len(self.ctx.items_received)
                 tracker_panel_scrollable = TrackerLayoutScrollable(do_scroll=(False, True), bar_width=10)
@@ -682,7 +682,7 @@ class ManualContext(SuperContext):
                                 # Label (for all item listings)
                                 sorted_items_received = sorted([
                                     i.item for i in self.ctx.items_received
-                                ], key=self.ctx.item_names.lookup_in_game)
+                                ])
 
                                 for network_item in sorted_items_received:
                                     item_name = self.ctx.item_names.lookup_in_game(network_item)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -459,7 +459,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2024_12_13 # YYYYMMDD
+    version = 2025_04_17 # YYYYMMDD
     found = False
 
     if "manual" not in icon_paths:


### PR DESCRIPTION
Sort order is a blocker for the next unstable, and we've paused client updates in the meantime, and we already have to accept some concession because of the KivyMD changes... so this PR is an additional concession to change sort order to id / non-alphabetical in the meantime. 

Goal is to revisit sort order once client changes are finalized to some extent.