### PR TITLE
fix crash cause by unbound item in create_items

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -115,11 +115,12 @@ class ManualWorld(World):
         for name in configured_item_names.values():
             if name == "__Victory__": continue
             if name == filler_item_name: continue # intentionally using the Game.py filler_item_name here because it's a non-Items item
-            if item.get("trap"):
-                traps.append(name)
 
             item = self.item_name_to_item[name]
             item_count = int(item.get("count", 1))
+
+            if item.get("trap"):
+                traps.append(name)
 
             if "category" in item:
                 if not is_item_enabled(self.multiworld, self.player, item):

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -62,7 +62,7 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
 # {"Item Name": {"progression": 2, "useful": 1}} <- This will create 3 items, with 2 classified as progression and 1 as useful
 # {"Item Name": {0b0110: 5}} <- If you know the special flag for the item classes, you can also define non-standard options. This setup
 #       will create 5 items that are the "useful trap" class
-def before_create_items_all(item_config: dict[str: int|dict], world: World, multiworld: Multiworld, player: int) -> dict[str: int|dict]:
+def before_create_items_all(item_config: dict[str: int|dict], world: World, multiworld: MultiWorld, player: int) -> dict[str: int|dict]:
     return item_config
 
 # The item pool before starting items are processed, in case you want to see the raw item pool at that stage
@@ -151,8 +151,8 @@ def before_write_spoiler(world: World, multiworld: MultiWorld, spoiler_handle) -
 
 # This is called when you want to add information to the hint text
 def before_extend_hint_information(hint_data: dict[int, dict[int, str]], world: World, multiworld: MultiWorld, player: int) -> None:
-    
-    ### Example way to use this hook: 
+
+    ### Example way to use this hook:
     # if player not in hint_data:
     #     hint_data.update({player: {}})
     # for location in multiworld.get_locations(player):
@@ -162,7 +162,7 @@ def before_extend_hint_information(hint_data: dict[int, dict[int, str]], world: 
     #     use this section to calculate the hint string
     #
     #     hint_data[player][location.address] = hint_string
-    
+
     pass
 
 def after_extend_hint_information(hint_data: dict[int, dict[int, str]], world: World, multiworld: MultiWorld, player: int) -> None:


### PR DESCRIPTION
Found this while redoing ItemValue to work more like AP does things:
this small change from [#131](https://github.com/ManualForArchipelago/Manual/pull/131/files#diff-6b39a2f1a6399aa39e427fb4c11a7b552e615a2d83a3c36aa6dd6ddbbb8281f4R120-L127) cause a crash
