### PR TITLE
ItemValue Simplified

### DIFF
--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -4,6 +4,7 @@ import pkgutil
 import json
 
 from BaseClasses import MultiWorld, Item
+from enum import IntEnum
 from typing import Optional, List, TYPE_CHECKING, Union, get_args, get_origin, Any
 from types import GenericAlias
 from worlds.AutoWorld import World
@@ -213,12 +214,22 @@ def format_to_valid_identifier(input: str) -> str:
         input = "_" + input
     return input.replace(" ", "_")
 
-def format_itemvalue_key(key: str) -> str:
-    """Convert the inputted key to the format used in state.has(key) to check/set the count of an item_value
+class ProgItemsCat(IntEnum):
+    VALUE = 1
+    CATEGORY = 2
+
+def format_state_prog_items_key(category: str|ProgItemsCat ,key: str) -> str:
+    """Convert the inputted key to the format used in state.has(key) to check/set the count of an item_value.
+    Using either one of the predefined categories or a custom string.
 
     Example: Coin -> MANUAL_VALUE_coin
     """
-    return f"MANUAL_VALUE_{format_to_valid_identifier(key.lower())}"
+    if isinstance(category, str):
+        cat_key = category.upper()
+    else:
+        cat_key = category.name
+
+    return f"MANUAL_{cat_key}_{format_to_valid_identifier(key.lower())}"
 
 def convert_string_to_type(input: str, target_type: type) -> Any:
     """Take a string and attempt to convert it to {target_type}

--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -4,7 +4,7 @@ import pkgutil
 import json
 
 from BaseClasses import MultiWorld, Item
-from typing import Optional, List, TYPE_CHECKING, Union, get_args, get_origin
+from typing import Optional, List, TYPE_CHECKING, Union, get_args, get_origin, Any
 from types import GenericAlias
 from worlds.AutoWorld import World
 from .hooks.Helpers import before_is_category_enabled, before_is_item_enabled, before_is_location_enabled
@@ -109,7 +109,7 @@ def is_location_enabled(multiworld: MultiWorld, player: int, location: "ManualLo
 
     return _is_manualobject_enabled(multiworld, player, location)
 
-def _is_manualobject_enabled(multiworld: MultiWorld, player: int, object: any) -> bool:
+def _is_manualobject_enabled(multiworld: MultiWorld, player: int, object: Any) -> bool:
     """Internal method: Check if a Manual Object has any category disabled by a yaml option.
     \nPlease use the proper is_'item/location'_enabled or is_'item/location'_name_enabled methods instead.
     """
@@ -213,7 +213,14 @@ def format_to_valid_identifier(input: str) -> str:
         input = "_" + input
     return input.replace(" ", "_")
 
-def convert_string_to_type(input: str, target_type: type) -> any:
+def format_itemvalue_key(key: str) -> str:
+    """Convert the inputted key to the format used in state.has(key) to check/set the count of an item_value
+
+    Example: Coin -> MANUAL_VALUE_coin
+    """
+    return f"MANUAL_VALUE_{format_to_valid_identifier(key.lower())}"
+
+def convert_string_to_type(input: str, target_type: type) -> Any:
     """Take a string and attempt to convert it to {target_type}
     \ntarget_type can be a single type(ex. str), an union (int|str), an Optional type (Optional[str]) or a combo of any of those (Optional[int|str])
     \nSpecial logic:

--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -225,7 +225,7 @@ def format_state_prog_items_key(category: str|ProgItemsCat ,key: str) -> str:
     Example: Coin -> MANUAL_VALUE_coin
     """
     if isinstance(category, str):
-        cat_key = category.upper()
+        cat_key = format_to_valid_identifier(category.upper())
     else:
         cat_key = category.name
 

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -5,7 +5,7 @@ from operator import eq, ge, le
 from .Regions import regionMap
 from .hooks import Rules
 from .Helpers import clamp, is_item_enabled, is_option_enabled, get_option_value, convert_string_to_type,\
-    format_to_valid_identifier, format_itemvalue_key
+    format_to_valid_identifier, format_state_prog_items_key, ProgItemsCat
 
 from BaseClasses import MultiWorld, CollectionState
 from worlds.AutoWorld import World
@@ -394,7 +394,7 @@ def ItemValue(state: CollectionState, player: int, valueCount: str):
     args: list[str] = valueCount.split(":")
     if not len(args) == 2 or not args[1].isnumeric():
         raise Exception(f"ItemValue needs a number after : so it looks something like 'ItemValue({args[0]}:12)'")
-    value_name = format_itemvalue_key(args[0])
+    value_name = format_state_prog_items_key(ProgItemsCat.VALUE, args[0])
     requested_count = int(args[1].strip())
     return state.has(value_name, player, requested_count)
 

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -4,7 +4,8 @@ from operator import eq, ge, le
 
 from .Regions import regionMap
 from .hooks import Rules
-from .Helpers import clamp, is_item_enabled, get_items_with_value, is_option_enabled, get_option_value, convert_string_to_type, format_to_valid_identifier
+from .Helpers import clamp, is_item_enabled, is_option_enabled, get_option_value, convert_string_to_type,\
+    format_to_valid_identifier, format_itemvalue_key
 
 from BaseClasses import MultiWorld, CollectionState
 from worlds.AutoWorld import World
@@ -384,47 +385,19 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
             args[index] = value
 
 
-def ItemValue(world: World, multiworld: MultiWorld, state: CollectionState, player: int, valueCount: str, skipCache: bool = False):
+def ItemValue(state: CollectionState, player: int, valueCount: str):
     """When passed a string with this format: 'valueName:int',
     this function will check if the player has collect at least 'int' valueName worth of items\n
-    eg. {ItemValue(Coins:12)} will check if the player has collect at least 12 coins worth of items\n
-    You can add a second string argument to disable creating/checking the cache like this:
-    '{ItemValue(Coins:12,Disable)}' it can be any string you want
+    eg. {ItemValue(Coins:12)} will check if the player has collect at least 12 coins worth of items
     """
 
-    valueCount = valueCount.split(":")
-    if not len(valueCount) == 2 or not valueCount[1].isnumeric():
-        raise Exception(f"ItemValue needs a number after : so it looks something like 'ItemValue({valueCount[0]}:12)'")
-    value_name = valueCount[0].lower().strip()
-    requested_count = int(valueCount[1].strip())
+    args: list[str] = valueCount.split(":")
+    if not len(args) == 2 or not args[1].isnumeric():
+        raise Exception(f"ItemValue needs a number after : so it looks something like 'ItemValue({args[0]}:12)'")
+    value_name = format_itemvalue_key(args[0])
+    requested_count = int(args[1].strip())
+    return state.has(value_name, player, requested_count)
 
-    if not hasattr(world, 'itemvalue_rule_cache'): #Cache made for optimization purposes
-        world.itemvalue_rule_cache = {}
-
-    if not world.itemvalue_rule_cache.get(player, {}):
-        world.itemvalue_rule_cache[player] = {}
-
-    if not skipCache:
-        if not world.itemvalue_rule_cache[player].get(value_name, {}):
-            world.itemvalue_rule_cache[player][value_name] = {
-                'state': {},
-                'count': -1,
-                }
-
-    if (skipCache or world.itemvalue_rule_cache[player][value_name].get('count', -1) == -1
-            or world.itemvalue_rule_cache[player][value_name].get('state') != dict(state.prog_items[player])):
-        # Run First Time, if state changed since last check or if skipCache has a value
-        existing_item_values = get_items_with_value(world, multiworld, value_name)
-        total_Count = 0
-        for name, value in existing_item_values.items():
-            count = state.count(name, player)
-            if count > 0:
-                total_Count += count * value
-        if skipCache:
-            return total_Count >= requested_count
-        world.itemvalue_rule_cache[player][value_name]['count'] = total_Count
-        world.itemvalue_rule_cache[player][value_name]['state'] = dict(state.prog_items[player])
-    return world.itemvalue_rule_cache[player][value_name]['count'] >= requested_count
 
 # Two useful functions to make require work if an item is disabled instead of making it inaccessible
 def OptOne(world: World, item: str, items_counts: Optional[dict] = None):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -20,7 +20,7 @@ from .Regions import create_regions
 from .Items import ManualItem
 from .Rules import set_rules
 from .Options import manual_options_data
-from .Helpers import is_item_enabled, get_option_value, get_items_for_player, resolve_yaml_option, format_itemvalue_key
+from .Helpers import is_item_enabled, get_option_value, get_items_for_player, resolve_yaml_option, format_state_prog_items_key, ProgItemsCat
 
 from BaseClasses import CollectionState, ItemClassification, Item
 from Options import PerGameCommonOptions
@@ -264,7 +264,7 @@ class ManualWorld(World):
         manual_item = self.item_name_to_item.get(item.name, {})
         if change and manual_item.get("value"):
             for key, value in manual_item["value"].items():
-                state.prog_items[item.player][format_itemvalue_key(key)] += int(value)
+                state.prog_items[item.player][format_state_prog_items_key(ProgItemsCat.VALUE, key)] += int(value)
         return change
 
     def remove(self, state: CollectionState, item: Item) -> bool:
@@ -272,7 +272,7 @@ class ManualWorld(World):
         manual_item = self.item_name_to_item.get(item.name, {})
         if change and manual_item.get("value"):
             for key, value in manual_item["value"].items():
-                state.prog_items[item.player][format_itemvalue_key(key)] -= int(value)
+                state.prog_items[item.player][format_state_prog_items_key(ProgItemsCat.VALUE, key)] -= int(value)
         return change
 
     def set_rules(self):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -33,7 +33,8 @@ from .hooks.World import \
     before_set_rules, after_set_rules, \
     before_generate_basic, after_generate_basic, \
     before_fill_slot_data, after_fill_slot_data, before_write_spoiler, \
-    before_extend_hint_information, after_extend_hint_information
+    before_extend_hint_information, after_extend_hint_information, \
+    after_collect_item, after_remove_item
 from .hooks.Data import hook_interpret_slot_data
 
 class ManualWorld(World):
@@ -265,6 +266,7 @@ class ManualWorld(World):
         if change and manual_item.get("value"):
             for key, value in manual_item["value"].items():
                 state.prog_items[item.player][format_state_prog_items_key(ProgItemsCat.VALUE, key)] += int(value)
+        after_collect_item(self, state, change, item)
         return change
 
     def remove(self, state: CollectionState, item: Item) -> bool:
@@ -273,6 +275,7 @@ class ManualWorld(World):
         if change and manual_item.get("value"):
             for key, value in manual_item["value"].items():
                 state.prog_items[item.player][format_state_prog_items_key(ProgItemsCat.VALUE, key)] -= int(value)
+        after_remove_item(self, state, change, item)
         return change
 
     def set_rules(self):

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -1,6 +1,6 @@
 # Object classes from AP core, to represent an entire MultiWorld and this individual World that's part of it
 from worlds.AutoWorld import World
-from BaseClasses import MultiWorld, CollectionState
+from BaseClasses import MultiWorld, CollectionState, Item
 
 # Object classes from Manual -- extending AP core -- representing items and locations that are used in generation
 from ..Items import ManualItem
@@ -12,7 +12,7 @@ from ..Locations import ManualLocation
 from ..Data import game_table, item_table, location_table, region_table
 
 # These helper methods allow you to determine if an option has been set, or what its value is, for any player in the multiworld
-from ..Helpers import is_option_enabled, get_option_value
+from ..Helpers import is_option_enabled, get_option_value, format_state_prog_items_key, ProgItemsCat
 
 # calling logging.info("message") anywhere below in this file will output the message to both console and log file
 import logging
@@ -43,7 +43,7 @@ def before_create_regions(world: World, multiworld: MultiWorld, player: int):
 # Called after regions and locations are created, in case you want to see or modify that information. Victory location is included.
 def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     # Use this hook to remove locations from the world
-    locationNamesToRemove = [] # List of location names
+    locationNamesToRemove: list[str] = [] # List of location names
 
     # Add your code here to calculate which locations to remove
 
@@ -52,8 +52,6 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
             for location in list(region.locations):
                 if location.name in locationNamesToRemove:
                     region.locations.remove(location)
-    if hasattr(multiworld, "clear_location_cache"):
-        multiworld.clear_location_cache()
 
 # This hook allows you to access the item names & counts before the items are created. Use this to increase/decrease the amount of a specific item in the pool
 # Valid item_config key/values:
@@ -62,7 +60,7 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
 # {"Item Name": {"progression": 2, "useful": 1}} <- This will create 3 items, with 2 classified as progression and 1 as useful
 # {"Item Name": {0b0110: 5}} <- If you know the special flag for the item classes, you can also define non-standard options. This setup
 #       will create 5 items that are the "useful trap" class
-def before_create_items_all(item_config: dict[str: int|dict], world: World, multiworld: Multiworld, player: int) -> dict[str: int|dict]:
+def before_create_items_all(item_config: dict[str, int|dict], world: World, multiworld: MultiWorld, player: int) -> dict[str, int|dict]:
     return item_config
 
 # The item pool before starting items are processed, in case you want to see the raw item pool at that stage
@@ -72,7 +70,7 @@ def before_create_items_starting(item_pool: list, world: World, multiworld: Mult
 # The item pool after starting items are processed but before filler is added, in case you want to see the raw item pool at that stage
 def before_create_items_filler(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
     # Use this hook to remove items from the item pool
-    itemNamesToRemove = [] # List of item names
+    itemNamesToRemove: list[str] = [] # List of item names
 
     # Add your code here to calculate which items to remove.
     #
@@ -130,12 +128,29 @@ def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, pl
     return item
 
 # This method is run towards the end of pre-generation, before the place_item options have been handled and before AP generation occurs
-def before_generate_basic(world: World, multiworld: MultiWorld, player: int) -> list:
+def before_generate_basic(world: World, multiworld: MultiWorld, player: int):
     pass
 
 # This method is run at the very end of pre-generation, once the place_item options have been handled and before AP generation occurs
 def after_generate_basic(world: World, multiworld: MultiWorld, player: int):
     pass
+
+# This method is run every time an item is added to the state, can be used to modify the value of an item.
+# IMPORTANT! Any changes made in this hook must be cancelled/undone in after_remove_item
+def after_collect_item(world: World, state: CollectionState, Changed: bool, item: Item):
+    # the following let you add to the Potato Item Value count
+    # if item.name == "Cooked Potato":
+    #     state.prog_items[item.player][format_state_prog_items_key(ProgItemsCat.VALUE, "Potato")] += 1
+    pass
+
+# This method is run every time an item is removed from the state, can be used to modify the value of an item.
+# IMPORTANT! Any changes made in this hook must be first done in after_collect_item
+def after_remove_item(world: World, state: CollectionState, Changed: bool, item: Item):
+    # the following let you undo the addition to the Potato Item Value count
+    # if item.name == "Cooked Potato":
+    #     state.prog_items[item.player][format_state_prog_items_key(ProgItemsCat.VALUE, "Potato")] -= 1
+    pass
+
 
 # This is called before slot data is set and provides an empty dict ({}), in case you want to modify it before Manual does
 def before_fill_slot_data(slot_data: dict, world: World, multiworld: MultiWorld, player: int) -> dict:
@@ -151,8 +166,8 @@ def before_write_spoiler(world: World, multiworld: MultiWorld, spoiler_handle) -
 
 # This is called when you want to add information to the hint text
 def before_extend_hint_information(hint_data: dict[int, dict[int, str]], world: World, multiworld: MultiWorld, player: int) -> None:
-    
-    ### Example way to use this hook: 
+
+    ### Example way to use this hook:
     # if player not in hint_data:
     #     hint_data.update({player: {}})
     # for location in multiworld.get_locations(player):
@@ -162,7 +177,7 @@ def before_extend_hint_information(hint_data: dict[int, dict[int, str]], world: 
     #     use this section to calculate the hint string
     #
     #     hint_data[player][location.address] = hint_string
-    
+
     pass
 
 def after_extend_hint_information(hint_data: dict[int, dict[int, str]], world: World, multiworld: MultiWorld, player: int) -> None:


### PR DESCRIPTION
Last december qwint shared a better way to do item values [here](https://discord.com/channels/1097532591650910289/1097538232914296944/1314704842731815004)
this is the implementation of it.

I also replaced all the wrong `any` to `Any` in helpers.py while I was there

This works by making it that every item when collected, add their values to the state that acts like regular items that can be found with state.has/count no more silly cache.

Since this uses regular AP logic, it become more open to outside modifications. 
I added Hooks so devs can do something whenever collect/remove is called.
It could let devs change the value of items or even create progressive items