### PR TITLE
fix item being counted twice in client

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -678,6 +678,8 @@ class ManualContext(SuperContext):
                                 # instead of reusing existing item listings, clear it all out and re-draw with the sorted list
                                 category_grid.clear_widgets()
                                 self.listed_items[category_name].clear()
+                                category_count = 0
+                                category_unique_name_count = 0
 
                                 # Label (for all item listings)
                                 sorted_items_received = sorted([


### PR DESCRIPTION
since we are pausing #115 / #139 im splitting this fix from those.
An example of the bug this fix can be found [here in the discord bug report](https://discord.com/channels/1097532591650910289/1343966388376834099)
but basicaly because we removed those 2 lines since last stable items are being counted twice sometime in the client
leading to some empty spaces and wrong counts in the parentheses next to category names