### PR TITLE
Fix before_create_items_all hook

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -132,13 +132,13 @@ class ManualWorld(World):
 
         for name, configs in items_config.items():
             total_created = 0
-            if type(configs) == int:
+            if type(configs) is int:
                 total_created = configs
                 for _ in range(configs):
                     new_item = self.create_item(name)
                     pool.append(new_item)
-            elif type(configs) == dict:
-                for cat, count in configs.values():
+            elif type(configs) is dict:
+                for cat, count in configs.items():
                     total_created += count
                     true_class = {
                         "filler": ItemClassification.filler,
@@ -163,7 +163,7 @@ class ManualWorld(World):
                     self.multiworld.early_items[self.player][name] = int(item["early"])
 
                 elif isinstance(item["early"],bool): #No need to deal with true vs false since false wont get here
-                    self.multiworld.early_items[self.player][name] = item_count
+                    self.multiworld.early_items[self.player][name] = total_created
 
                 else:
                     raise Exception(f"Item {name}'s 'early' has an invalid value of '{item['early']}'. \nA boolean or an integer was expected.")
@@ -177,7 +177,7 @@ class ManualWorld(World):
                     self.multiworld.local_early_items[self.player][name] = int(item["local_early"])
 
                 elif isinstance(item["local_early"],bool):
-                    self.multiworld.local_early_items[self.player][name] = item_count
+                    self.multiworld.local_early_items[self.player][name] = total_created
 
                 else:
                     raise Exception(f"Item {name}'s 'local_early' has an invalid value of '{item['local_early']}'. \nA boolean or an integer was expected.")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -111,7 +111,7 @@ class ManualWorld(World):
         traps = []
         configured_item_names = self.item_id_to_name.copy()
 
-        items_config = {}
+        items_config: dict[str, int|dict[str, int]] = {}
         for name in configured_item_names.values():
             if name == "__Victory__": continue
             if name == filler_item_name: continue # intentionally using the Game.py filler_item_name here because it's a non-Items item
@@ -140,15 +140,14 @@ class ManualWorld(World):
             elif type(configs) is dict:
                 for cat, count in configs.items():
                     total_created += count
-                    true_class = {
-                        "filler": ItemClassification.filler,
-                        "trap": ItemClassification.trap,
-                        "useful": ItemClassification.useful,
-                        "progression_skip_balancing": ItemClassification.progression_skip_balancing,
-                        "progression": ItemClassification.progression
-                    }.get(cat, cat)
-                    if not isinstance(true_class, ItemClassification):
-                        raise Exception(f"Item override for {name} improperly defined")
+                    try:
+                        if cat.startswith('0b'):
+                            true_class = ItemClassification(int(cat, base=0))
+                        else:
+                            true_class = ItemClassification[cat]
+                    except Exception as ex:
+                        raise Exception(f"Item override '{cat}' for {name} improperly defined\n\n{type(ex).__name__}:{ex}")
+
                     for _ in range(count):
                         new_item = self.create_item(name, true_class)
                         pool.append(new_item)
@@ -185,7 +184,7 @@ class ManualWorld(World):
 
         pool = before_create_items_starting(pool, self, self.multiworld, self.player)
 
-        items_started = []
+        items_started: list[Item] = []
 
         if starting_items:
             for starting_item_block in starting_items:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -140,13 +140,16 @@ class ManualWorld(World):
             elif type(configs) is dict:
                 for cat, count in configs.items():
                     total_created += count
-                    try:
-                        if cat.startswith('0b'):
-                            true_class = ItemClassification(int(cat, base=0))
-                        else:
-                            true_class = ItemClassification[cat]
-                    except Exception as ex:
-                        raise Exception(f"Item override '{cat}' for {name} improperly defined\n\n{type(ex).__name__}:{ex}")
+                    if isinstance(cat, ItemClassification):
+                        true_class = cat
+                    else:
+                        try:
+                            if cat.startswith('0b'):
+                                true_class = ItemClassification(int(cat, base=0))
+                            else:
+                                true_class = ItemClassification[cat]
+                        except Exception as ex:
+                            raise Exception(f"Item override '{cat}' for {name} improperly defined\n\n{type(ex).__name__}:{ex}")
 
                     for _ in range(count):
                         new_item = self.create_item(name, true_class)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -144,7 +144,9 @@ class ManualWorld(World):
                         true_class = cat
                     else:
                         try:
-                            if cat.startswith('0b'):
+                            if isinstance(cat, int):
+                                true_class = ItemClassification(cat)
+                            elif cat.startswith('0b'):
                                 true_class = ItemClassification(int(cat, base=0))
                             else:
                                 true_class = ItemClassification[cat]

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -62,6 +62,7 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
 # {"Item Name": {"progression": 2, "useful": 1}} <- This will create 3 items, with 2 classified as progression and 1 as useful
 # {"Item Name": {0b0110: 5}} <- If you know the special flag for the item classes, you can also define non-standard options. This setup
 #       will create 5 items that are the "useful trap" class
+# {"Item Name": {ItemClassification.useful: 5}} <- You can also use the classification directly
 def before_create_items_all(item_config: dict[str: int|dict], world: World, multiworld: MultiWorld, player: int) -> dict[str: int|dict]:
     return item_config
 


### PR DESCRIPTION
for a manual im doing I decided to use the before_create_items_all hook, but using any dict would fail 
After fixing that I decided to test everything the comments says should work and thus found that the binary version mentionned in the comments also do not work

Here is what the comments looks like for the hooks currently:
```python
# This hook allows you to access the item names & counts before the items are created. Use this to increase/decrease the amount of a specific item in the pool
# Valid item_config key/values:
# {"Item Name": 5} <- This will create qty 5 items using all the default settings
# {"Item Name": {"useful": 7}} <- This will create qty 7 items and force them to be classified as useful
# {"Item Name": {"progression": 2, "useful": 1}} <- This will create 3 items, with 2 classified as progression and 1 as useful
# {"Item Name": {0b0110: 5}} <- If you know the special flag for the item classes, you can also define non-standard options. This setup
#       will create 5 items that are the "useful trap" class
```
before 9fb61d1 only the first example worked
before 3896093 the last example wouldnt work

I decided to change from the predefined dict of ItemClassification to just calling ItemClassification itself since its simpler and is more future proof if base AP add a new classification later or something
and while at it I just let devs provide the ItemClassification directly in a2b66dd