### PR TITLE
fix the item counts for location requirements desync with UT

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -102,6 +102,7 @@ def evaluate_postfix(expr: str, location: str) -> bool:
     return stack.pop()
 
 def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
+    world.get_item_counts(player, True)
     # this is only called when the area (think, location or region) has a "requires" field that is a string
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -102,7 +102,6 @@ def evaluate_postfix(expr: str, location: str) -> bool:
     return stack.pop()
 
 def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
-    world.get_item_counts(player, True)
     # this is only called when the area (think, location or region) has a "requires" field that is a string
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
@@ -281,7 +280,8 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
             return checkRequireStringForArea(state, area)
         else:  # item access is in dict form
             return checkRequireDictForArea(state, area)
-
+    # calling get_item_counts here make sure the item_counts cache is created correctly for UT
+    world.get_item_counts(player, True)
     used_location_names = []
     # Region access rules
     for region in regionMap.keys():


### PR DESCRIPTION
Seems the item_counts was made too late and for some reason UT and only UT couldn't see the precollected items
by creating it at the start of set_rules UT can now see precollected items too

this makes it work with both game.json's starting_items and the player yamls's start_inventory and start_inventory_from_pool
in start_inventory case item are added to the pool and just added to the counts thus for  :all and any :% will grow with the items
but start_inventory_from_pool should now work correctly since the items already exists

the only way this will break is if a custom rule made in the rules.py hook call the reset of the item count cache and thus break UT again
Im not sure the best way to prevent that from happening, could potential create an invalid player in the cache (-1) and test for it and not reset if present or something