### PR TITLE
Fix missing region name sometimes when "Invalid Requires" message is shown

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -288,7 +288,10 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
         used_location_names.extend([l.name for l in multiworld.get_region(region, player).locations])
         if region != "Menu":
             for exitRegion in multiworld.get_region(region, player).entrances:
-                def fullRegionCheck(state: CollectionState, region=regionMap[region]):
+                def fullRegionCheck(state: CollectionState, region=regionMap[region], region_name=exitRegion.name):
+                    region['name'] = region_name
+                    region['is_region'] = True
+
                     return fullLocationOrRegionCheck(state, region)
 
                 add_rule(world.get_entrance(exitRegion.name), fullRegionCheck)


### PR DESCRIPTION
The recent improvements to the "Invalid Logic" message added clearer messaging when requires were incorrectly formatted, but missed a place where requires were checked. This PR adds the missing info in that place.

Current impact is that users still get the "Invalid Requires" message, and it does correctly flag that it's a region... but the region name is missing. So not critical, but would be nice to fix in next release.