### PR TITLE
Simplifying Item_counts

### DIFF
--- a/src/Rules.py
+++ b/src/Rules.py
@@ -106,7 +106,6 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
 
-
         # Preparing some variables for exception messages
         area_type = "region" if area.get("is_region",False) else "location"
         area_name = area.get("name", f"unknown with these parameters: {area}")
@@ -287,7 +286,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
 
     # Get the "real" item counts of item in the pool/placed/starting_items
     prog_counts = world.get_item_counts(player, only_progression=True)
-    all_counts = world.get_item_counts(player, only_progression=False)
+    all_counts = world.get_item_counts(player)
     used_location_names = []
     # Region access rules
     for region in regionMap.keys():

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -106,6 +106,9 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
 
+        # Get the "real" item counts of item in the pool/placed/starting_items
+        items_counts = world.get_item_counts(player, only_progression=True)
+
         # Preparing some variables for exception messages
         area_type = "region" if area.get("is_region",False) else "location"
         area_name = area.get("name", f"unknown with these parameters: {area}")
@@ -278,8 +281,6 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
         else:  # item access is in dict form
             return checkRequireDictForArea(state, area)
 
-    # Get the "real" item counts of item in the pool/placed/starting_items
-    items_counts = world.get_item_counts(player, only_progression=True)
     used_location_names = []
     # Region access rules
     for region in regionMap.keys():

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -402,7 +402,7 @@ def ItemValue(state: CollectionState, player: int, valueCount: str):
 
 
 # Two useful functions to make require work if an item is disabled instead of making it inaccessible
-def OptOne(world: World, item: str, items_counts: Optional[dict] = None):
+def OptOne(world: "ManualWorld", item: str, items_counts: Optional[dict] = None):
     """Check if the passed item (with or without ||) is enabled, then this returns |item:count|
     where count is clamped to the maximum number of said item in the itempool.\n
     Eg. requires: "{OptOne(|DisabledItem|)} and |other items|" become "|DisabledItem:0| and |other items|" if the item is disabled.
@@ -410,7 +410,7 @@ def OptOne(world: World, item: str, items_counts: Optional[dict] = None):
     if item == "":
         return "" #Skip this function if item is left blank
     if not items_counts:
-        items_counts = world.get_item_counts()
+        items_counts = world.get_item_counts(only_progression=True)
 
     require_type = 'item'
 
@@ -441,14 +441,14 @@ def OptOne(world: World, item: str, items_counts: Optional[dict] = None):
         return f"|{item_name}:{item_count}|"
 
 # OptAll check the passed require string and loop every item to check if they're enabled,
-def OptAll(world: World, multiworld: MultiWorld, state: CollectionState, player: int, requires: str):
+def OptAll(world: "ManualWorld", requires: str):
     """Check the passed require string and loop every item to check if they're enabled,
     then returns the require string with items counts adjusted using OptOne\n
     eg. requires: "{OptAll(|DisabledItem| and |@CategoryWithModifedCount:10|)} and |other items|"
     become "|DisabledItem:0| and |@CategoryWithModifedCount:2| and |other items|" """
     requires_list = requires
 
-    items_counts = world.get_item_counts()
+    items_counts = world.get_item_counts(only_progression=True)
 
     functions = {}
     if requires_list == "":

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -172,12 +172,6 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
                 item_name = item_parts[0].strip()
                 item_count = item_parts[1].strip()
 
-            if item_count.endswith('!'):
-                items_counts = all_counts
-                item_count = item_count.removesuffix("!")
-            else:
-                items_counts = prog_counts
-
             total = 0
 
             if require_type == 'category':
@@ -285,8 +279,7 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
             return checkRequireDictForArea(state, area)
 
     # Get the "real" item counts of item in the pool/placed/starting_items
-    prog_counts = world.get_item_counts(player, only_progression=True)
-    all_counts = world.get_item_counts(player)
+    items_counts = world.get_item_counts(player, only_progression=True)
     used_location_names = []
     # Region access rules
     for region in regionMap.keys():

--- a/src/Rules.py
+++ b/src/Rules.py
@@ -106,8 +106,6 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
 
-        # Get the "real" item counts of item in the pool/placed/starting_items
-        items_counts = world.get_item_counts(player)
 
         # Preparing some variables for exception messages
         area_type = "region" if area.get("is_region",False) else "location"
@@ -174,6 +172,12 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
             if len(item_parts) > 1:
                 item_name = item_parts[0].strip()
                 item_count = item_parts[1].strip()
+
+            if item_count.endswith('!'):
+                items_counts = all_counts
+                item_count = item_count.removesuffix("!")
+            else:
+                items_counts = prog_counts
 
             total = 0
 
@@ -280,8 +284,10 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
             return checkRequireStringForArea(state, area)
         else:  # item access is in dict form
             return checkRequireDictForArea(state, area)
-    # calling get_item_counts here make sure the item_counts cache is created correctly for UT
-    world.get_item_counts(player, True)
+
+    # Get the "real" item counts of item in the pool/placed/starting_items
+    prog_counts = world.get_item_counts(player, only_progression=True)
+    all_counts = world.get_item_counts(player, only_progression=False)
     used_location_names = []
     # Region access rules
     for region in regionMap.keys():

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -477,19 +477,21 @@ class ManualWorld(World):
 
         return item_pool
 
-    def get_item_counts(self, player: Optional[int] = None, reset: bool = False, pool: list[Item] | None = None, only_progression: bool = False) -> Counter[str]:
+    def get_item_counts(self, player: Optional[int] = None, reset: None = None, pool: list[Item] | None = None, only_progression: bool = False) -> Counter[str]:
         """Returns the player real item counts.\n
         If you provide an item pool using the pool argument, then it's item counts will be returned.
         Otherwise, this function will only work after create_items, before then an empty Counter is returned.\n
         The only_progression argument let you filter the items to only get the count of progression items."""
         if player is None:
             player = self.player
-        if reset:
+
+        if reset is not None:
             Utils.deprecate("the 'reset' argument of get_item_counts has been deprecated to increase the stability of item counts.\
-                \nIt should be removed and if required you might be able to replace it by using the pool argument")
+                \nIt should be removed. If you require a new up to date count you can get it using the 'pool' argument.\
+                \nThat result wont be saved to world unless you override the values of world.progression_counts or world.item_counts depending on if you counted only the items with progresion or not.")
 
         if pool is not None:
-            return Counter([i.name for i in pool if not only_progression or ItemClassification.progression in i.classification])
+            return Counter([i.name for i in pool if not only_progression or i.advancement])
 
         if only_progression:
             return self.progression_counts.get(player, Counter())

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@ from base64 import b64encode
 import logging
 import os
 import json
-from typing import Callable, Optional
+from typing import Callable, Optional, Counter
 import webbrowser
 
 import Utils
@@ -58,8 +58,8 @@ class ManualWorld(World):
 
     filler_item_name = filler_item_name
 
-    item_counts: dict[int, dict[str, int]] = {}
-    progression_counts: dict[int, dict[str, int]] = {}
+    item_counts: dict[int, Counter[str]] = {}
+    progression_counts: dict[int, Counter[str]] = {}
     start_inventory = {}
 
     location_id_to_name = location_id_to_name
@@ -477,10 +477,10 @@ class ManualWorld(World):
 
         return item_pool
 
-    def get_item_counts(self, player: Optional[int] = None, reset: bool = False, pool: list[Item] | None = None, only_progression: bool = False) -> dict[str, int]:
+    def get_item_counts(self, player: Optional[int] = None, reset: bool = False, pool: list[Item] | None = None, only_progression: bool = False) -> Counter[str]:
         """Returns the player real item counts.\n
         If you provide an item pool using the pool argument, then it's item counts will be returned.
-        Otherwise, this function will only work after create_items, before then an empty dict is returned.\n
+        Otherwise, this function will only work after create_items, before then an empty Counter is returned.\n
         The only_progression argument let you filter the items to only get the count of progression items."""
         if player is None:
             player = self.player
@@ -488,12 +488,12 @@ class ManualWorld(World):
             Utils.deprecate("reset has been deprecated to increase the stability of item counts.")
 
         if pool is not None:
-            return {i.name: pool.count(i) for i in pool if not only_progression or ItemClassification.progression in i.classification}
+            return Counter([i.name for i in pool if not only_progression or ItemClassification.progression in i.classification])
 
         if only_progression:
-            return self.progression_counts.get(player, {})
+            return self.progression_counts.get(player, Counter())
         else:
-            return self.item_counts.get(player, {})
+            return self.item_counts.get(player, Counter())
 
 
     def client_data(self):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -241,8 +241,8 @@ class ManualWorld(World):
         self.multiworld.itempool += pool
 
         real_pool = pool + items_started
-        self.item_counts[self.player] = {i.name: real_pool.count(i) for i in real_pool}
-        self.progression_counts[self.player] = {i.name: real_pool.count(i) for i in real_pool if ItemClassification.progression in i.classification}
+        self.item_counts[self.player] = self.get_item_counts(pool=real_pool)
+        self.progression_counts[self.player] = self.get_item_counts(pool=real_pool, only_progression=True)
 
     def create_item(self, name: str, class_override: Optional['ItemClassification']=None) -> Item:
         name = before_create_item(name, self, self.multiworld, self.player)
@@ -477,14 +477,18 @@ class ManualWorld(World):
 
         return item_pool
 
-    def get_item_counts(self, player: Optional[int] = None, reset: bool = False, only_progression: bool = False) -> dict[str, int]:
-        """Returns the player real item counts\n
-        Only work after create_items, before an empty dict is returned\n
-        The only_progression argument let you filter the items to only get the count of progression items"""
+    def get_item_counts(self, player: Optional[int] = None, reset: bool = False, pool: list[Item] | None = None, only_progression: bool = False) -> dict[str, int]:
+        """Returns the player real item counts.\n
+        If you provide an item pool using the pool argument, then it's item counts will be returned.
+        Otherwise, this function will only work after create_items, before then an empty dict is returned.\n
+        The only_progression argument let you filter the items to only get the count of progression items."""
         if player is None:
             player = self.player
         if reset:
             Utils.deprecate("reset has been deprecated to increase the stability of item counts.")
+
+        if pool is not None:
+            return {i.name: pool.count(i) for i in pool if not only_progression or ItemClassification.progression in i.classification}
 
         if only_progression:
             return self.progression_counts.get(player, {})

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -59,7 +59,7 @@ class ManualWorld(World):
     filler_item_name = filler_item_name
 
     item_counts: dict[int, Counter[str]] = {}
-    progression_counts: dict[int, Counter[str]] = {}
+    item_counts_progression: dict[int, Counter[str]] = {}
     start_inventory = {}
 
     location_id_to_name = location_id_to_name
@@ -242,7 +242,7 @@ class ManualWorld(World):
 
         real_pool = pool + items_started
         self.item_counts[self.player] = self.get_item_counts(pool=real_pool)
-        self.progression_counts[self.player] = self.get_item_counts(pool=real_pool, only_progression=True)
+        self.item_counts_progression[self.player] = self.get_item_counts(pool=real_pool, only_progression=True)
 
     def create_item(self, name: str, class_override: Optional['ItemClassification']=None) -> Item:
         name = before_create_item(name, self, self.multiworld, self.player)
@@ -477,7 +477,7 @@ class ManualWorld(World):
 
         return item_pool
 
-    def get_item_counts(self, player: Optional[int] = None, reset: None = None, pool: list[Item] | None = None, only_progression: bool = False) -> Counter[str]:
+    def get_item_counts(self, player: Optional[int] = None, pool: list[Item] | None | bool = None, only_progression: bool = False) -> Counter[str]:
         """Returns the player real item counts.\n
         If you provide an item pool using the pool argument, then it's item counts will be returned.
         Otherwise, this function will only work after create_items, before then an empty Counter is returned.\n
@@ -485,16 +485,17 @@ class ManualWorld(World):
         if player is None:
             player = self.player
 
-        if reset is not None:
+        if isinstance(pool, bool):
             Utils.deprecate("the 'reset' argument of get_item_counts has been deprecated to increase the stability of item counts.\
                 \nIt should be removed. If you require a new up to date count you can get it using the 'pool' argument.\
-                \nThat result wont be saved to world unless you override the values of world.progression_counts or world.item_counts depending on if you counted only the items with progresion or not.")
+                \nThat result wont be saved to world unless you override the values of world.item_counts_progression or world.item_counts depending on if you counted only the items with progresion or not.")
+            pool = None
 
         if pool is not None:
             return Counter([i.name for i in pool if not only_progression or i.advancement])
 
         if only_progression:
-            return self.progression_counts.get(player, Counter())
+            return self.item_counts_progression.get(player, Counter())
         else:
             return self.item_counts.get(player, Counter())
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -485,7 +485,8 @@ class ManualWorld(World):
         if player is None:
             player = self.player
         if reset:
-            Utils.deprecate("reset has been deprecated to increase the stability of item counts.")
+            Utils.deprecate("the 'reset' argument of get_item_counts has been deprecated to increase the stability of item counts.\
+                \nIt should be removed and if required you might be able to replace it by using the pool argument")
 
         if pool is not None:
             return Counter([i.name for i in pool if not only_progression or ItemClassification.progression in i.classification])


### PR DESCRIPTION
Rework get_item_counts to only create the item counts once(1 time) at the end of create_items
this should once and for all fix the counts by using the pool straight out of create_items instead of trying to recreate the item pool later from multiworld and precollected
I also made rules get the count of progression items by default ~~but
I also included a ! suffix if people want to use the old logic of All being every copy of an item not just the ones with progressions in their classification 
the ! suffix is a something that can and probably should be something else is I just dont know what, It could even be removed entirely~~ since I remembered State doesnt count non-progression items while generating meaning any All! would potentially never be in logic while generating

This was tested  in 2 tests using the same test manual with 3 copies of an item with 1 in game.json starting_items
- [x] 1.  1 in start_inventory_from_pool
- [x] 2.  1 in start_inventory