### PR TITLE
Location schema should require the name field

### DIFF
--- a/schemas/Manual.locations.schema.json
+++ b/schemas/Manual.locations.schema.json
@@ -101,7 +101,8 @@
                     "type": "integer"
                 },
                 "_comment": {"$ref": "#/definitions/comment"}
-            }
+            },
+            "required": ["name"]
         },
         "Require": {
             "type": ["string", "array", "object"],


### PR DESCRIPTION
Found from this support request: https://discord.com/channels/1097532591650910289/1098306155492687892/1384530775139156109

Basically, they got a gen exception for some missing location names, and the bot didn't catch. Because we didn't have name marked as required for locations.