### PR TITLE
DataValidation: Show the game name that has validation errors

### DIFF
--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -450,7 +450,7 @@ def runPreFillDataValidation(world: World, multiworld: MultiWorld):
         raise Exception(f"\n\n{heading} \n\n{newline.join([' - ' + str(validation_error) for validation_error in validation_errors])}\n\n")
 
 # Called during stage_assert_generate
-def runGenerationDataValidation() -> None:
+def runGenerationDataValidation(cls) -> None:
     validation_errors = []
 
     # check that requires have correct item names in locations and regions
@@ -506,7 +506,6 @@ def runGenerationDataValidation() -> None:
     except ValidationError as e: validation_errors.append(e)
 
     if len(validation_errors) > 0:
-        creator = DataValidation.game_table.get('creator') or DataValidation.game_table.get('player', '')
-        heading = f"ValidationError(s) in Manual_{DataValidation.game_table['game']}_{creator}:";
+        heading = f"ValidationError(s) in {cls.game}:";
 
         raise Exception("\n\n%s \n\n%s\n\n" % (heading, "\n".join([' - ' + str(validation_error) for validation_error in validation_errors])))

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -90,7 +90,7 @@ class ManualWorld(World):
 
     @classmethod
     def stage_assert_generate(cls, multiworld) -> None:
-        runGenerationDataValidation()
+        runGenerationDataValidation(cls)
 
 
     def create_regions(self):


### PR DESCRIPTION
This PR updates the validation to show the game name in which the validation error(s) occurred, so it's easier to track down the problematic world in a multiworld. Updates both pre-validation and validation that occurs at pre_fill.