### PR TITLE
DataValidation: Bug in inaccessible non-starting region check

### DIFF
--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -397,12 +397,12 @@ class DataValidation():
 
     @staticmethod
     def checkForNonStartingRegionsThatAreUnreachable():
-        using_starting_regions = len([region for region in DataValidation.region_table if "starting" in DataValidation.region_table[region] and not DataValidation.region_table[region]["starting"]]) > 0
+        using_starting_regions = len([region for region in DataValidation.region_table if "starting" in DataValidation.region_table[region]]) > 0
 
         if not using_starting_regions:
             return
 
-        nonstarting_regions = [region for region in DataValidation.region_table if "starting" in DataValidation.region_table[region] and not DataValidation.region_table[region]["starting"]]
+        nonstarting_regions = [region for region in DataValidation.region_table if not DataValidation.region_table[region].get("starting")]
 
         for nonstarter in nonstarting_regions:
             regions_that_connect_to = [region for region in DataValidation.region_table if "connects_to" in DataValidation.region_table[region] and nonstarter in DataValidation.region_table[region]["connects_to"]]


### PR DESCRIPTION
This PR fixes a bug that prevented the DataValidation check for non-starting regions that are inaccessible (due to a missing or improper "connects_to") from running. 