### PR TITLE
Complex Item Count aka Item types config not just for hooks devs

### DIFF
--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -95,7 +95,7 @@
                     "default": false
                 },
                 "advanced_types": {
-                    "description": "(Optional) (Advanced) A dictionary of how many copy of certain type this item has. \nUsing the format {\"type\": int,\"otherType\": int} where type can be the string name of a type ('progression') or an integer/binary representation of its type(s) ('6' or '0b0110')",
+                    "description": "(Optional) (Advanced) A dictionary of how many copy of certain type this item has. \nUsing the format {\"type\": int,\"otherType\": int} where type can be the string name of a type ('progression') or an integer/binary representation of its type(s) ('6' or '0b0110') \nIt can also be a concatenated form of those using a + eg. 'progression + useful'",
                     "type": "object",
                     "patternProperties": {
                         "^.+$": {

--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -94,6 +94,20 @@
                     "type": ["boolean", "integer"],
                     "default": false
                 },
+                "advanced_types": {
+                    "description": "(Optional) (Advanced) A dictionary of how many copy of certain type this item has. \nUsing the format {\"type\": int,\"otherType\": int} where type can be the string name of a type ('progression') or an integer/binary representation of its type(s) ('6' or '0b0110')",
+                    "type": "object",
+                    "patternProperties": {
+                        "^.+$": {
+                            "anyOf": [
+                                {
+                                    "type": "integer",
+                                    "description": "A Count of how many copy of this item with this type will be in generation. Must be 'name':integer \neg. \"useful\": 10"
+                                }
+                            ]
+                        }
+                    }
+                },
                 "id": {
                     "description": "(Optional) Skips the item ID forward to the given value.\nThis can be used to provide buffer space for future items.",
                     "type": "integer"

--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -94,8 +94,8 @@
                     "type": ["boolean", "integer"],
                     "default": false
                 },
-                "advanced_types": {
-                    "description": "(Optional) (Advanced) A dictionary of how many copy of certain type this item has. \nUsing the format {\"type\": int,\"otherType\": int} where type can be the string name of a type ('progression') or an integer/binary representation of its type(s) ('6' or '0b0110') \nIt can also be a concatenated form of those using a + eg. 'progression + useful'",
+                "complex_count": {
+                    "description": "(Optional) (Advanced) A dictionary of how many copy of certain type this item has. \nWhere the properties keys must be the string name of a type ('progression') or an integer/binary representation of its type(s) ('6' or '0b0110') \nIt can also be a concatenated form of those using a + eg. 'progression + useful'",
                     "type": "object",
                     "patternProperties": {
                         "^.+$": {

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -183,20 +183,25 @@ class DataValidation():
             if not item.get("complex_count"):
                 continue
             for cat, count in item["complex_count"].items():
+                cat = str(cat)
                 if count == 0:
                     continue
                 try:
                     def stringCheck(string: str):
                         if string.isdigit():
                             ItemClassification(int(string))
-                        elif "+" in string:
-                            for substring in string.split("+"):
-                                stringCheck(substring.strip())
                         elif string.startswith('0b'):
                             ItemClassification(int(string, base=0))
                         else:
                             ItemClassification[string]
-                    stringCheck(cat)
+
+                    if "+" in cat:
+                        for substring in cat.split("+"):
+                            stringCheck(substring.strip())
+
+                    else:
+                        stringCheck(cat)
+
                 except KeyError as ex:
                     raise ValidationError(f"Item '{item['name']}''s complex_count '{cat}' is misspelled or does not exist.\n Valid names are {', '.join(ItemClassification.__members__.keys())} \n\n{type(ex).__name__}:{ex}")
                 except Exception as ex:
@@ -223,16 +228,19 @@ class DataValidation():
                         def stringCheck(string: str) -> ItemClassification:
                             if string.isdigit():
                                 true_class = ItemClassification(int(string))
-                            elif "+" in string:
-                                true_class = ItemClassification.filler
-                                for substring in string.split("+"):
-                                    true_class |= stringCheck(substring.strip())
                             elif string.startswith('0b'):
                                 true_class = ItemClassification(int(string, base=0))
                             else:
                                 true_class = ItemClassification[string]
                             return true_class
-                        true_class = stringCheck(cat)
+
+                        if "+" in cat:
+                            true_class = ItemClassification.filler
+                            for substring in cat.split("+"):
+                                true_class |= stringCheck(substring.strip())
+                        else:
+                            true_class = stringCheck(cat)
+
                     except:
                         # Skip since this validation error is dealt with in checkItemsHasValidComplexCount
                         true_class = ItemClassification.filler

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -178,11 +178,11 @@ class DataValidation():
                 raise ValidationError("Region %s is set for location %s, but the region is misspelled or does not exist." % (location["region"], location["name"]))
 
     @staticmethod
-    def checkItemsHasValidAdvancedTypes():
+    def checkItemsHasValidComplexCount():
         for item in DataValidation.item_table:
-            if not item.get("advanced_types"):
+            if not item.get("complex_count"):
                 continue
-            for cat, count in item["advanced_types"].items():
+            for cat, count in item["complex_count"].items():
                 if count == 0:
                     continue
                 try:
@@ -198,9 +198,9 @@ class DataValidation():
                             ItemClassification[string]
                     stringCheck(cat)
                 except KeyError as ex:
-                    raise ValidationError(f"Item '{item['name']}''s advanced_types '{cat}' is misspelled or does not exist.\n Valid names are {', '.join(ItemClassification.__members__.keys())} \n\n{type(ex).__name__}:{ex}")
+                    raise ValidationError(f"Item '{item['name']}''s complex_count '{cat}' is misspelled or does not exist.\n Valid names are {', '.join(ItemClassification.__members__.keys())} \n\n{type(ex).__name__}:{ex}")
                 except Exception as ex:
-                    raise ValidationError(f"Item '{item['name']}''s advanced_types '{cat}' was improperly defined\n\n{type(ex).__name__}:{ex}")
+                    raise ValidationError(f"Item '{item['name']}''s complex_count '{cat}' was improperly defined\n\n{type(ex).__name__}:{ex}")
 
     @staticmethod
     def checkItemsThatShouldBeRequired():
@@ -213,9 +213,9 @@ class DataValidation():
             if item.get("progression_skip_balancing"):
                 continue
             # if any of the advanced type is already progression then no check needed
-            if item.get("advanced_types"):
+            if item.get("complex_count"):
                 has_progression = False
-                for cat, count in item["advanced_types"].items():
+                for cat, count in item["complex_count"].items():
                     cat = str(cat)
                     if count == 0:
                         continue
@@ -234,7 +234,7 @@ class DataValidation():
                             return true_class
                         true_class = stringCheck(cat)
                     except:
-                        # Skip since this validation error is dealt with in checkItemsHasValidAdvancedTypes
+                        # Skip since this validation error is dealt with in checkItemsHasValidComplexCount
                         true_class = ItemClassification.filler
                     if ItemClassification.progression in true_class:
                         has_progression = True
@@ -519,8 +519,8 @@ def runGenerationDataValidation(cls) -> None:
     try: DataValidation.checkRegionNamesInLocations()
     except ValidationError as e: validation_errors.append(e)
 
-    # check that any advanced_types used in items are valid
-    try: DataValidation.checkItemsHasValidAdvancedTypes()
+    # check that any complex_count used in items are valid
+    try: DataValidation.checkItemsHasValidComplexCount()
     except ValidationError as e: validation_errors.append(e)
 
     # check that items that are required by locations and regions are also marked required

--- a/src/DataValidation.py
+++ b/src/DataValidation.py
@@ -186,12 +186,17 @@ class DataValidation():
                 if count == 0:
                     continue
                 try:
-                    if cat.isdigit():
-                        ItemClassification(int(cat))
-                    elif cat.startswith('0b'):
-                        ItemClassification(int(cat, base=0))
-                    else:
-                        ItemClassification[cat]
+                    def stringCheck(string: str):
+                        if string.isdigit():
+                            ItemClassification(int(string))
+                        elif "+" in string:
+                            for substring in string.split("+"):
+                                stringCheck(substring.strip())
+                        elif string.startswith('0b'):
+                            ItemClassification(int(string, base=0))
+                        else:
+                            ItemClassification[string]
+                    stringCheck(cat)
                 except KeyError as ex:
                     raise ValidationError(f"Item '{item['name']}''s advanced_types '{cat}' is misspelled or does not exist.\n Valid names are {', '.join(ItemClassification.__members__.keys())} \n\n{type(ex).__name__}:{ex}")
                 except Exception as ex:
@@ -215,12 +220,19 @@ class DataValidation():
                     if count == 0:
                         continue
                     try:
-                        if cat.isdigit():
-                            true_class = ItemClassification(int(cat))
-                        elif cat.startswith('0b'):
-                            true_class = ItemClassification(int(cat, base=0))
-                        else:
-                            true_class = ItemClassification[cat]
+                        def stringCheck(string: str) -> ItemClassification:
+                            if string.isdigit():
+                                true_class = ItemClassification(int(string))
+                            elif "+" in string:
+                                true_class = ItemClassification.filler
+                                for substring in string.split("+"):
+                                    true_class |= stringCheck(substring.strip())
+                            elif string.startswith('0b'):
+                                true_class = ItemClassification(int(string, base=0))
+                            else:
+                                true_class = ItemClassification[string]
+                            return true_class
+                        true_class = stringCheck(cat)
                     except:
                         # Skip since this validation error is dealt with in checkItemsHasValidAdvancedTypes
                         true_class = ItemClassification.filler

--- a/src/Helpers.py
+++ b/src/Helpers.py
@@ -6,14 +6,10 @@ import json
 
 from BaseClasses import MultiWorld, Item
 from enum import IntEnum
-from typing import Optional, List, TYPE_CHECKING, Union, get_args, get_origin, Any
+from typing import Optional, List, Union, get_args, get_origin, Any
 from types import GenericAlias
 from worlds.AutoWorld import World
 from .hooks.Helpers import before_is_category_enabled, before_is_item_enabled, before_is_location_enabled
-
-if TYPE_CHECKING:
-    from .Items import ManualItem
-    from .Locations import ManualLocation
 
 # blatantly copied from the minecraft ap world because why not
 def load_data_file(*args) -> dict:
@@ -87,7 +83,7 @@ def is_item_name_enabled(multiworld: MultiWorld, player: int, item_name: str) ->
 
     return is_item_enabled(multiworld, player, item)
 
-def is_item_enabled(multiworld: MultiWorld, player: int, item: "ManualItem") -> bool:
+def is_item_enabled(multiworld: MultiWorld, player: int, item: dict[str, Any]) -> bool:
     """Check if an item has been disabled by a yaml option."""
     hook_result = before_is_item_enabled(multiworld, player, item)
     if hook_result is not None:
@@ -103,7 +99,7 @@ def is_location_name_enabled(multiworld: MultiWorld, player: int, location_name:
 
     return is_location_enabled(multiworld, player, location)
 
-def is_location_enabled(multiworld: MultiWorld, player: int, location: "ManualLocation") -> bool:
+def is_location_enabled(multiworld: MultiWorld, player: int, location: dict[str, Any]) -> bool:
     """Check if a location has been disabled by a yaml option."""
     hook_result = before_is_location_enabled(multiworld, player, location)
     if hook_result is not None:
@@ -111,7 +107,7 @@ def is_location_enabled(multiworld: MultiWorld, player: int, location: "ManualLo
 
     return _is_manualobject_enabled(multiworld, player, location)
 
-def _is_manualobject_enabled(multiworld: MultiWorld, player: int, object: Any) -> bool:
+def _is_manualobject_enabled(multiworld: MultiWorld, player: int, object: dict[str, Any]) -> bool:
     """Internal method: Check if a Manual Object has any category disabled by a yaml option.
     \nPlease use the proper is_'item/location'_enabled or is_'item/location'_name_enabled methods instead.
     """

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -154,12 +154,20 @@ class ManualWorld(World):
                         try:
                             if isinstance(cat, int):
                                 true_class = ItemClassification(cat)
-                            elif cat.isdigit():
-                                true_class = ItemClassification(int(cat))
-                            elif cat.startswith('0b'):
-                                true_class = ItemClassification(int(cat, base=0))
                             else:
-                                true_class = ItemClassification[cat]
+                                def stringCheck(string: str) ->  ItemClassification:
+                                    if string.isdigit():
+                                        true_class = ItemClassification(int(string))
+                                    elif "+" in string:
+                                        true_class = ItemClassification.filler
+                                        for substring in string.split("+"):
+                                            true_class |= stringCheck(substring.strip())
+                                    elif string.startswith('0b'):
+                                        true_class = ItemClassification(int(string, base=0))
+                                    else:
+                                        true_class = ItemClassification[string]
+                                    return true_class
+                                true_class = stringCheck(cat)
                         except Exception as ex:
                             raise Exception(f"Item override '{cat}' for {name} improperly defined\n\n{type(ex).__name__}:{ex}")
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@ from base64 import b64encode
 import logging
 import os
 import json
-from typing import Callable, Optional, Counter
+from typing import Callable, Optional, Counter, Any
 import webbrowser
 
 import Utils
@@ -74,7 +74,7 @@ class ManualWorld(World):
     def get_filler_item_name(self) -> str:
         return hook_get_filler_item_name(self, self.multiworld, self.player) or self.filler_item_name
 
-    def interpret_slot_data(self, slot_data: dict[str, any]):
+    def interpret_slot_data(self, slot_data: dict[str, Any]):
         #this is called by tools like UT
         if not slot_data:
             return False
@@ -126,11 +126,15 @@ class ManualWorld(World):
             if item.get("trap"):
                 traps.append(name)
 
-            if "category" in item:
-                if not is_item_enabled(self.multiworld, self.player, item):
-                    item_count = 0
+            if not is_item_enabled(self.multiworld, self.player, item):
+                items_config[name] = 0
 
-            items_config[name] = item_count
+            else:
+                if item.get("advanced_types"):
+                    items_config[name] = item["advanced_types"]
+
+                else:
+                    items_config[name] = item_count
 
         items_config = before_create_items_all(items_config, self, self.multiworld, self.player)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -154,6 +154,8 @@ class ManualWorld(World):
                         try:
                             if isinstance(cat, int):
                                 true_class = ItemClassification(cat)
+                            elif cat.isdigit():
+                                true_class = ItemClassification(int(cat))
                             elif cat.startswith('0b'):
                                 true_class = ItemClassification(int(cat, base=0))
                             else:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -130,8 +130,8 @@ class ManualWorld(World):
                 items_config[name] = 0
 
             else:
-                if item.get("advanced_types"):
-                    items_config[name] = item["advanced_types"]
+                if item.get("complex_count"):
+                    items_config[name] = item["complex_count"]
 
                 else:
                     items_config[name] = item_count

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -158,16 +158,19 @@ class ManualWorld(World):
                                 def stringCheck(string: str) ->  ItemClassification:
                                     if string.isdigit():
                                         true_class = ItemClassification(int(string))
-                                    elif "+" in string:
-                                        true_class = ItemClassification.filler
-                                        for substring in string.split("+"):
-                                            true_class |= stringCheck(substring.strip())
                                     elif string.startswith('0b'):
                                         true_class = ItemClassification(int(string, base=0))
                                     else:
                                         true_class = ItemClassification[string]
                                     return true_class
-                                true_class = stringCheck(cat)
+
+                                if "+" in cat:
+                                    true_class = ItemClassification.filler
+                                    for substring in cat.split("+"):
+                                        true_class |= stringCheck(substring.strip())
+
+                                else:
+                                    true_class = stringCheck(cat)
                         except Exception as ex:
                             raise Exception(f"Item override '{cat}' for {name} improperly defined\n\n{type(ex).__name__}:{ex}")
 

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -8,11 +8,8 @@
                 "Left Side"
             ],
             "value": {"star": 5, "coins": 3},
-            "advanced_types": {"3": 1, "0b0011": 0, "useful + progression": 0, "useful": 1},
-            "_comment": ["For advanced_types '3' is the equivalent of '0b0011' aka 'useful + progression'",
-                "All of these would work if their count wasn't 0",
-                "In this example a copy will be created that is useful & progression and another will be created just useful"
-            ]
+            "complex_count": {"useful + progression": 1, "useful": 1},
+            "_comment": "In this example a copy of the 'Jill' item will be created that is useful & progression and another will be created just useful"
         },
         {
             "name": "Shuma-Gorath",

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -8,9 +8,10 @@
                 "Left Side"
             ],
             "value": {"star": 5, "coins": 3},
-            "advanced_types": {"3": 1, "0b0011": 0, "useful": 1},
-            "_comment": ["for advanced_types '3' is the equivalent of '0b0011' aka progression + useful",
-                "in this example a copy will be created that is prog useful and another will be created just useful"
+            "advanced_types": {"3": 1, "0b0011": 0, "useful + progression": 0, "useful": 1},
+            "_comment": ["For advanced_types '3' is the equivalent of '0b0011' aka 'useful + progression'",
+                "All of these would work if their count wasn't 0",
+                "In this example a copy will be created that is useful & progression and another will be created just useful"
             ]
         },
         {

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -8,7 +8,10 @@
                 "Left Side"
             ],
             "value": {"star": 5, "coins": 3},
-            "progression": true
+            "advanced_types": {"3": 1, "0b0011": 0, "useful": 1},
+            "_comment": ["for advanced_types '3' is the equivalent of '0b0011' aka progression + useful",
+                "in this example a copy will be created that is prog useful and another will be created just useful"
+            ]
         },
         {
             "name": "Shuma-Gorath",

--- a/src/hooks/Helpers.py
+++ b/src/hooks/Helpers.py
@@ -1,9 +1,6 @@
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Any
 from BaseClasses import MultiWorld, Item, Location
 
-if TYPE_CHECKING:
-    from ..Items import ManualItem
-    from ..Locations import ManualLocation
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the category, False to disable it, or None to use the default behavior
@@ -12,10 +9,10 @@ def before_is_category_enabled(multiworld: MultiWorld, player: int, category_nam
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the item, False to disable it, or None to use the default behavior
-def before_is_item_enabled(multiworld: MultiWorld, player: int, item: "ManualItem") -> Optional[bool]:
+def before_is_item_enabled(multiworld: MultiWorld, player: int, item:  dict[str, Any]) -> Optional[bool]:
     return None
 
 # Use this if you want to override the default behavior of is_option_enabled
 # Return True to enable the location, False to disable it, or None to use the default behavior
-def before_is_location_enabled(multiworld: MultiWorld, player: int, location: "ManualLocation") -> Optional[bool]:
+def before_is_location_enabled(multiworld: MultiWorld, player: int, location:  dict[str, Any]) -> Optional[bool]:
     return None


### PR DESCRIPTION
when I made #148 I had the idea to make the item config that are currently hook only be available to non-hook devs.
What this PR does exactly is that it adds the "complex_count" properties to items.json that let devs set custom counts for each ItemClassification via the existing hook-only items_config that I tweaked just a bit to work with string version of ints and support multi classification keys using the `+` character

example: 
```json
{
    "name": "Jump upgrade",
    "complex_count": {"useful + progression": 1, "useful": 1},
}
```
This would create a copy of the "Jump upgrade" item with both useful and progression classification and another just useful

Complex Count bypasses some of the other properties ("count" and any regular classification properties (eg. "progression"))
This forced me to fix some of the datavalidations that failed when "progression" is not included