### PR TITLE
CommonClient uses the game value before connect now, which broke the client... again

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -63,7 +63,7 @@ class ManualClientCommandProcessor(ClientCommandProcessor):
 
 class ManualContext(SuperContext):
     command_processor = ManualClientCommandProcessor
-    game = "not set"  # this is changed in server_auth below based on user input
+    game = None  # this is changed in server_auth below based on user input
     items_handling = 0b111  # full remote
     tags = {"AP"}
 


### PR DESCRIPTION
Apparently ctx.game is being used prior to connecting now if set, so having it set to a nonsense string causes a KeyError.

So this PR changes it to None until we set it at connect, so CC ignores it.