### PR TITLE
Forgot to bump client version when fixing client bork in 0.6.3

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -531,7 +531,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2025_04_17 # YYYYMMDD
+    version = 2025_08_12 # YYYYMMDD
     found = False
 
     if "manual" not in icon_paths:


### PR DESCRIPTION
What the title says. Already updated the most recent stable apworld in the release.