### PR TITLE
Make add_filler_items deprecation message more clear

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -422,7 +422,7 @@ class ManualWorld(World):
     One thing to remember is the more you loop the longer generation will take. So probably leave it as is unless you really needs it."""
 
     def add_filler_items(self, item_pool, traps):
-        Utils.deprecate(f"You're calling the deprecated add_filler_items() function. Use the adjust_filler_items() function instead.")
+        Utils.deprecate("You're calling the deprecated add_filler_items() function. Use the adjust_filler_items() function instead.")
         return self.adjust_filler_items(item_pool, traps)
 
     def adjust_filler_items(self, item_pool, traps):


### PR DESCRIPTION
Current deprecation warning for `add_filler_items` only shows what should be used instead, but the error line shown is the call to Utils.deprecate and there's no stack trace for where this was triggered from. 

This PR includes the name of the offending (deprecated) function in the deprecation message, so the user can track down where they're calling that to change it.