### PR TITLE
Fix the UT link in the docs to point to the UT channel

### DIFF
--- a/docs/play/get-apworld.md
+++ b/docs/play/get-apworld.md
@@ -5,6 +5,6 @@ If you are not, please read through AP's guide on multiworld setup first: https:
 
 1. Locate the worlds you want to play and their associated yamls, as well as the location of your Archipelago installation.
 2. Go into your Archipelago folder, then into the `lib` folder, then the `worlds` folder. You should see all your existing worlds; move the Manual .apworlds here as well.
-3. (Recommended): Download [Universal Tracker](https://discord.com/channels/1097532591650910289/1176939614985011200) and add it to lib/worlds
+3. (Recommended): Download [Universal Tracker](https://discord.com/channels/731205301247803413/1367270230635839539) and add it to lib/worlds
 
 Next: [Connecting](connect-client.md)


### PR DESCRIPTION
Insanely free PR review :stuck_out_tongue_winking_eye:  

UT link was pointing to our feature request thread for adding UT support, which only had a link to UT's old future-game-design thread. Updated to be a link to UT's newer channel in the AP Discord server instead.