### PR TITLE
Add UT glitch logic support

### DIFF
--- a/schemas/Manual.game.schema.json
+++ b/schemas/Manual.game.schema.json
@@ -21,7 +21,7 @@
             "type": "string"
         },
         "glitches_item_name": {
-            "description": "Name of the Special item UT uses for you to mark a location as accessible out of logic (with glitches). This system is disabled if left empty.",
+            "description": "(Optional) Name of the Special item UT uses for you to mark a location as accessible out of logic (with glitches). That system is disabled if this property is left empty.",
             "type": "string",
             "default": null
         },

--- a/schemas/Manual.game.schema.json
+++ b/schemas/Manual.game.schema.json
@@ -20,6 +20,11 @@
             "description": "Name of the filler items that get placed when there's no more real items to place.",
             "type": "string"
         },
+        "glitches_item_name": {
+            "description": "Name of the Special item UT uses for you to mark a location as accessible out of logic (with glitches). This system is disabled if left empty.",
+            "type": "string",
+            "default": null
+        },
         "starting_items": {
             "description": "(Optional) Starting inventory",
             "type":"array",

--- a/src/Data.py
+++ b/src/Data.py
@@ -68,6 +68,10 @@ DataValidation.location_table = location_table
 DataValidation.event_table = event_table
 DataValidation.region_table = region_table
 
+# Add UT's glitch item if required
+if game_table.get("glitches_item_name"):
+    DataValidation.event_table = DataValidation.event_table + [{"name": game_table["glitches_item_name"]}]
+
 # might as well save this for other uses in tests
 DataValidation.location_name_to_location = {l.get("name", f"unknown location {key}"): l for key, l in enumerate(DataValidation.location_table)}
 # since "copy_location" just changes data its handled here to simplify things

--- a/src/Game.py
+++ b/src/Game.py
@@ -1,8 +1,9 @@
 from .Data import game_table
 
-game_name = "Manual_%s_%s" % (game_table["game"], game_table["creator"])
-filler_item_name = game_table["filler_item_name"] if "filler_item_name" in game_table else "Filler"
-starting_items = game_table["starting_items"] if "starting_items" in game_table else None
+game_name: str = "Manual_%s_%s" % (game_table["game"], game_table["creator"])
+filler_item_name: str = game_table["filler_item_name"] if "filler_item_name" in game_table else "Filler"
+glitches_item_name: str | None = game_table["glitches_item_name"] if "glitches_item_name" in game_table else None
+starting_items: list[dict]|None = game_table["starting_items"] if "starting_items" in game_table else None
 
 if "starting_index" in game_table:
     try:

--- a/src/Game.py
+++ b/src/Game.py
@@ -1,9 +1,9 @@
 from .Data import game_table
 
 game_name: str = "Manual_%s_%s" % (game_table["game"], game_table["creator"])
-filler_item_name: str = game_table["filler_item_name"] if "filler_item_name" in game_table else "Filler"
+filler_item_name: str | list[str] = game_table["filler_item_name"] if "filler_item_name" in game_table else "Filler"
 glitches_item_name: str | None = game_table["glitches_item_name"] if "glitches_item_name" in game_table else None
-starting_items: list[dict]|None = game_table["starting_items"] if "starting_items" in game_table else None
+starting_items: list[dict] | None = game_table["starting_items"] if "starting_items" in game_table else None
 
 if "starting_index" in game_table:
     try:

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -477,7 +477,7 @@ class ManualContext(SuperContext):
                 config.setdefaults("universal-tracker", {
                     "block_unreachable_location_press": "Yes",
                     "display_glitched_locations": "Yes",
-                    "allow_glitched_location_press": "No"
+                    "allow_glitched_location_press": "Yes"
                 })
 
             def build_settings(self, settings: Settings):

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -121,7 +121,8 @@ class ManualContext(SuperContext):
     region_table = {}
     category_table = {}
 
-    tracker_reachable_locations = []
+    tracker_reachable_locations: list[str] = []
+    tracker_glitched_locations: list[str] = []
     tracker_reachable_events = []
 
     set_deathlink = False
@@ -134,19 +135,31 @@ class ManualContext(SuperContext):
     items_sorting = SortingOrderItem.default.name
     locations_sorting = SortingOrderLoc.default.name
     block_unreachable_location_press = True
+    display_glitched_locations = True
+    allow_glitched_location_press = True
 
     colors = {
         'location_default': [219/255, 218/255, 213/255, 1],
         'location_in_logic': [2/255, 242/255, 42/255, 1],
+        'location_in_glitched_logic': [247/255, 255/255, 119/255, 1],
         'category_even_default': [0.5, 0.5, 0.5, 0.1],
         'category_odd_default': [1.0, 1.0, 1.0, 0.0],
         'category_in_logic': [2/255, 82/255, 2/255, 1],
+        'category_in_glitched_logic': [172/255, 179/255, 81/255, 1],
         'deathlink_received': [1, 0, 0, 1],
         'deathlink_primed': [1, 1, 1, 1],
         'deathlink_sent': [0, 1, 0, 1],
         'game_select_button': [200/255, 200/255, 200/255, 1],
         'header_background': [15/255, 80/255, 112/255, 1]
     }
+    def get_colors_hex(self, color: str) -> str:
+        color_array = self.colors[color]
+        r = int(color_array[0] * 255)
+        g = int(color_array[1] * 255)
+        b = int(color_array[2] * 255)
+        a = int(color_array[3] * 255)
+
+        return f"{r:02x}{g:02x}{b:02x}{format(a, '02x') if a < 255 else ''}"
 
     def __init__(self, server_address, password, game, player_name) -> None:
         super(ManualContext, self).__init__(server_address, password)
@@ -155,6 +168,8 @@ class ManualContext(SuperContext):
             super().set_callback(self.on_tracker_updated) # Universal Tracker takes this func and calls it when updateTracker is called
             if hasattr(self, "set_events_callback"):
                 super().set_events_callback(self.on_tracker_events) # Universal Tracker takes this func and calls it when events are calculated
+            if hasattr(self, "set_glitches_callback"):
+                super().set_glitches_callback(self.on_glitches_call) # Universal Tracker takes this func and calls it when OOL glitched location are calculated
 
         self.send_index: int = 0
         self.syncing = False
@@ -281,6 +296,11 @@ class ManualContext(SuperContext):
     def on_tracker_events(self, events: list[str]):
         self.tracker_reachable_events = events
         if events:
+            self.ui.request_update_tracker_and_locations_table(update_highlights=True)
+
+    def on_glitches_call(self, glitched_locations: list[str]):
+        self.tracker_glitched_locations = glitched_locations
+        if glitched_locations:
             self.ui.request_update_tracker_and_locations_table(update_highlights=True)
 
     def is_event_visible(self, event_name, category_name):
@@ -417,6 +437,8 @@ class ManualContext(SuperContext):
                 self.ctx.items_sorting = self.config.get('manual', 'items_sorting_order')
                 self.ctx.locations_sorting = self.config.get('manual', 'locations_sorting_order')
                 self.ctx.block_unreachable_location_press = True if self.config.get('universal-tracker', 'block_unreachable_location_press') == "Yes" else False
+                self.ctx.display_glitched_locations = True if self.config.get('universal-tracker', 'display_glitched_locations') == "Yes" else False
+                self.ctx.allow_glitched_location_press = True if self.config.get('universal-tracker', 'allow_glitched_location_press') == "Yes" else False
 
                 self.manual_game_layout = BoxLayout(orientation="horizontal", size_hint_y=None, height=dp(30))
 
@@ -453,7 +475,9 @@ class ManualContext(SuperContext):
                     "locations_sorting_order": SortingOrderLoc.default.name
                 })
                 config.setdefaults("universal-tracker", {
-                    "block_unreachable_location_press": "Yes"
+                    "block_unreachable_location_press": "Yes",
+                    "display_glitched_locations": "Yes",
+                    "allow_glitched_location_press": "No"
                 })
 
             def build_settings(self, settings: Settings):
@@ -492,7 +516,23 @@ class ManualContext(SuperContext):
                             "title": "Stop accidental button press",
                             "section": "universal-tracker",
                             "key": "block_unreachable_location_press",
-                            "desc": "Should only green location be able to be pressed",
+                            "desc": "Should only reachable location be able to be pressed",
+                            "values": ["No", "Yes"]
+                        },
+                        {
+                            "type": "bool",
+                            "title": "See Glitched Logic",
+                            "section": "universal-tracker",
+                            "key": "display_glitched_locations",
+                            "desc": "Should locations marked as accessible OOL be shown in Yellow",
+                            "values": ["No", "Yes"]
+                        },
+                        {
+                            "type": "bool",
+                            "title": "Count glitched location as reachable for the press protection",
+                            "section": "universal-tracker",
+                            "key": "allow_glitched_location_press",
+                            "desc": "Should locations marked as accessible OOL not be protected from being pressed",
                             "values": ["No", "Yes"]
                         },
                     ])
@@ -513,6 +553,12 @@ class ManualContext(SuperContext):
                 elif section == "universal-tracker":
                     if key == "block_unreachable_location_press":
                         self.ctx.block_unreachable_location_press = True if value == "Yes" else False
+                    elif key == "display_glitched_locations":
+                        self.ctx.display_glitched_locations = True if value == "Yes" else False
+                        self.build_tracker_and_locations_table()
+                        self.request_update_tracker_and_locations_table()
+                    elif key == "allow_glitched_location_press":
+                        self.ctx.allow_glitched_location_press = True if value == "Yes" else False
 
             def clear_lists(self):
                 self.listed_items = {"(No Category)": []}
@@ -998,6 +1044,7 @@ class ManualContext(SuperContext):
                                 category_name = re.sub(r"\s\(\d+\/?(\d+)?\)$", "", category_label.text)
                                 category_count = 0
                                 reachable_count = 0
+                                reachable_glitch_count = 0
 
                                 buttons_to_remove = []
 
@@ -1030,6 +1077,10 @@ class ManualContext(SuperContext):
                                                     location_button.background_color = self.ctx.colors['location_in_logic']
                                                     reachable_count += 1
 
+                                                elif self.ctx.display_glitched_locations and location_button.victory and "__Victory__" in self.ctx.tracker_glitched_locations:
+                                                    location_button.background_color = self.ctx.colors['location_in_glitched_logic']
+                                                    reachable_glitch_count += 1
+
                                                 continue
 
                                         if location_button.id and location_button.id not in self.ctx.missing_locations:
@@ -1040,10 +1091,14 @@ class ManualContext(SuperContext):
                                             continue
 
                                         was_reachable = False
+                                        was_reachable_glitched = False
 
                                         if location_button.text in self.ctx.tracker_reachable_locations:
                                             location_button.background_color = self.ctx.colors['location_in_logic']
                                             was_reachable = True
+                                        elif self.ctx.display_glitched_locations and location_button.text in self.ctx.tracker_glitched_locations:
+                                            location_button.background_color = self.ctx.colors['location_in_glitched_logic']
+                                            was_reachable_glitched = True
                                         else:
                                             location_button.background_color = self.ctx.colors['location_default']
 
@@ -1055,7 +1110,8 @@ class ManualContext(SuperContext):
 
                                             if was_reachable:
                                                 reachable_count += 1
-
+                                            elif was_reachable_glitched:
+                                                reachable_glitch_count += 1
                                             category_count += 1
 
                                 for location_button in buttons_to_remove:
@@ -1069,18 +1125,26 @@ class ManualContext(SuperContext):
                                 if scrollview_height < 10:
                                     scrollview_height = 50
 
-                                count_text = category_count
+                                count_text: str = str(category_count)
 
                                 if tracker_loaded:
-                                    count_text = "{}/{}".format(reachable_count, category_count)
+                                    if self.ctx.display_glitched_locations and reachable_glitch_count:
+                                        count_text = f"{reachable_count}/{category_count} ({reachable_glitch_count})"
+                                    else:
+                                        count_text = f"{reachable_count}/{category_count}"
 
-                                category_name = re.sub(r"\s\(\d+\/?(\d+)?\)$", "", category_label.text)
+                                category_name = re.sub(r"\s\(\d+\/?([\d\s]+)?(\(\d+\))?\)$", "", category_label.text)
                                 category_label.text = "%s (%s)" % (category_name, count_text)
 
                                 if reachable_count > 0:
                                     # treeviewlabels don't have background color. because #justkivythings.
                                     category_label.even_color = self.ctx.colors['category_in_logic']
                                     category_label.odd_color = self.ctx.colors['category_in_logic']
+                                    category_label.odd_color[3] = 0.9
+                                elif self.ctx.display_glitched_locations and reachable_glitch_count > 0:
+                                    category_label.even_color = self.ctx.colors['category_in_glitched_logic']
+                                    category_label.odd_color = self.ctx.colors['category_in_glitched_logic']
+                                    category_label.odd_color[3] = 0.9
                                 else:
                                     category_label.even_color = self.ctx.colors['category_even_default']
                                     category_label.odd_color = self.ctx.colors['category_odd_default']
@@ -1103,12 +1167,18 @@ class ManualContext(SuperContext):
                     return
 
                 if location_id:
-                    if tracker_loaded and self.ctx.block_unreachable_location_press and button.text not in self.ctx.tracker_reachable_locations:
-                        logger.debug(f"button for location '{button.text}' was pressed while unreachable")
-                    else:
-                        self.ctx.locations_checked.append(location_id)
-                        self.ctx.syncing = True
-                        button.parent.remove_widget(button)
+                    if tracker_loaded and self.ctx.block_unreachable_location_press:
+                        if button.text in self.ctx.tracker_reachable_locations:
+                            pass
+                        elif self.ctx.allow_glitched_location_press and button.text in self.ctx.tracker_glitched_locations:
+                            pass
+                        else:
+                            logger.debug(f"button for location '{button.text}' was pressed while unreachable")
+                            return
+
+                    self.ctx.locations_checked.append(location_id)
+                    self.ctx.syncing = True
+                    button.parent.remove_widget(button)
 
                     # message = [{"cmd": 'LocationChecks', "locations": [location_id]}]
                     # self.ctx.send_msgs(message)

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -1170,7 +1170,7 @@ class ManualContext(SuperContext):
                     if tracker_loaded and self.ctx.block_unreachable_location_press:
                         if button.text in self.ctx.tracker_reachable_locations:
                             pass
-                        elif self.ctx.allow_glitched_location_press and button.text in self.ctx.tracker_glitched_locations:
+                        elif self.ctx.display_glitched_locations and self.ctx.allow_glitched_location_press and button.text in self.ctx.tracker_glitched_locations:
                             pass
                         else:
                             logger.debug(f"button for location '{button.text}' was pressed while unreachable")

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -173,14 +173,6 @@ class ManualContext(SuperContext):
         'game_select_button': [200/255, 200/255, 200/255, 1],
         'header_background': [15/255, 80/255, 112/255, 1]
     }
-    def get_colors_hex(self, color: str) -> str:
-        color_array = self.colors[color]
-        r = int(color_array[0] * 255)
-        g = int(color_array[1] * 255)
-        b = int(color_array[2] * 255)
-        a = int(color_array[3] * 255)
-
-        return f"{r:02x}{g:02x}{b:02x}{format(a, '02x') if a < 255 else ''}"
 
     def __init__(self, server_address, password, game, player_name) -> None:
         super(ManualContext, self).__init__(server_address, password)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,7 @@ from worlds.generic.Rules import forbid_items_for_player
 from worlds.LauncherComponents import Component, SuffixIdentifier, components, Type, launch_subprocess, icon_paths
 
 from .Data import item_table, location_table, event_table, region_table, category_table
-from .Game import game_name, filler_item_name, starting_items
+from .Game import game_name, filler_item_name, starting_items, glitches_item_name
 from .Meta import world_description, world_webworld
 from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups, victory_names, event_name_to_event
 from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups
@@ -71,6 +71,7 @@ class ManualWorld(World):
 
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True
+    glitches_item_name: str | None = glitches_item_name
 
     def get_filler_item_name(self) -> str:
         return hook_get_filler_item_name(self, self.multiworld, self.player) or self.filler_item_name
@@ -264,6 +265,9 @@ class ManualWorld(World):
 
     def create_item(self, name: str, class_override: Optional['ItemClassification']=None) -> Item:
         name = before_create_item(name, self, self.multiworld, self.player)
+
+        if name == self.glitches_item_name:
+            return ManualItem(name, class_override or ItemClassification.progression, None, self.player)
 
         item = self.item_name_to_item[name]
         classification: ItemClassification = ItemClassification.filler

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -568,7 +568,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2026_01_02 # YYYYMMDD
+    version = 2026_03_20 # YYYYMMDD
     found = False
 
     if "manual" not in icon_paths:

--- a/src/data/game.json
+++ b/src/data/game.json
@@ -4,7 +4,7 @@
     "creator": "ManualTeam",
 
     "filler_item_name": "Free Character of Your Choice",
-    "glitches_item_name": "[UT Glitched logic Item]",
+    "glitches_item_name": "[UT Glitches]",
 
     "starting_items": [
         {

--- a/src/data/game.json
+++ b/src/data/game.json
@@ -4,6 +4,7 @@
     "creator": "ManualTeam",
 
     "filler_item_name": "Free Character of Your Choice",
+    "glitches_item_name": "[UT Glitched logic Item]",
 
     "starting_items": [
         {

--- a/src/data/locations.json
+++ b/src/data/locations.json
@@ -29,7 +29,7 @@
         {
             "name": "Beat the Game - Shuma-Gorath",
             "category": ["Unlocked Teams", "Right Side"],
-            "requires": "|Shuma-Gorath|",
+            "requires": "|Shuma-Gorath| or |[UT Glitches]|",
             "hint_entrance": "Unlock Shuma-Gorath"
         },
         {


### PR DESCRIPTION
This PR add support for UT OOL location display.
This is done using a special Event Item that can be added to any requirement.
Said item's name can be set in game.json.
Any location which requirement work with this item get displayed in Yellow in the tracker tab and with this PR in our tab too
With this PR any category with a location available OOL will have the count of OOL location added next to its original count in parenteses
<img width="531" height="475" alt="image" src="https://github.com/user-attachments/assets/e26d770a-badd-42d1-91a6-ba06a1ff7650" />

I added new settings to disable this OOL display entirerly and choose if this bypasses the location button protection
<img width="855" height="247" alt="image" src="https://github.com/user-attachments/assets/bd41849d-83d4-4c89-a9d3-172d3fb9c306" />
