### PR TITLE
Add starting items to ManualWorld to allow interacting with in hooks

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -66,6 +66,7 @@ class ManualWorld(World):
     location_name_to_location = location_name_to_location
     location_name_groups = location_name_groups
     victory_names = victory_names
+    starting_items = starting_items
 
     event_name_to_event = event_name_to_event
 


### PR DESCRIPTION
This PR adds the ability to set starting items from within hooks. Useful when there are items that the player could start with or could be placed into generation depending on settings.

```py
def before_create_items_starting(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:

    ### Handle Modifications to the Starting Inventory
    # for x_location, a value of 0 means starting inventory, hence the "not"
    option_item_pairs = [
        (not(get_option_value(multiworld, player, "mark_location")),"Teleport-Mark"),
        (not(get_option_value(multiworld, player, "mount_location")),"Slot-Mount")
    ]

    for option, item in option_item_pairs:
        starting_item_block = format_starting_item_block(item)
        if option: # add to starting item if option enabled
            world.starting_items.append(starting_item_block)
        elif starting_item_block in world.starting_items: # remove if option not enabled (prevents issues with multiple worlds overlapping)
            world.starting_items.remove(starting_item_block)
```