### PR TITLE
Client: Category sorting & Goal protection

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -179,7 +179,7 @@ class ManualContext(SuperContext):
 
         self.send_index: int = 0
         self.syncing = False
-        self.game = game
+        self.game: str = game
         self.username = player_name
 
     async def server_auth(self, password_requested: bool = False):
@@ -218,6 +218,11 @@ class ManualContext(SuperContext):
             return self.game
         from .Game import game_name  # This will at least give us the name of a manual they've installed
         return Utils.persistent_load().get("client", {}).get("last_manual_game", game_name)
+
+    def get_location_UT_alias_by_id(self, id) -> str|None:
+        if hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
+            return AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
+        return None
 
     def get_location_by_name(self, name) -> dict[str, Any]:
         location = self.location_table.get(name)
@@ -836,7 +841,9 @@ class ManualContext(SuperContext):
                     category_scroll.add_widget(category_layout)
 
                     for location_id in self.listed_locations[location_category]:
-                        location_button = TreeViewButton(text=self.ctx.location_names.lookup_in_game(location_id), size_hint=(None, None), height=30, width=400)
+                        extra = f' ({alias})' if (alias := self.ctx.get_location_UT_alias_by_id(location_id)) is not None else ''
+                        text = f"{self.ctx.location_names.lookup_in_game(location_id)}{extra}"
+                        location_button = TreeViewButton(text=text, size_hint=(None, None), height=30, width=400)
                         location_button.bind(on_release=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
                         location_button.id = location_id
                         location_button.location_name = self.ctx.location_names.lookup_in_game(location_id)

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -148,6 +148,7 @@ class ManualContext(SuperContext):
     deathlink_out = False
 
     visible_events: dict[str, dict[str, Any]]  = {}
+    location_id_to_alias: dict[str, str] = {}
 
     search_term = ""
     items_sorting = SortingOrderItem.default.name
@@ -220,9 +221,11 @@ class ManualContext(SuperContext):
         return Utils.persistent_load().get("client", {}).get("last_manual_game", game_name)
 
     def get_location_UT_alias_by_id(self, id) -> str|None:
-        if hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
-            return AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
-        return None
+        alias = self.location_id_to_alias.get(str(id), None)
+        # Kept a fallback if its not in slotdata
+        if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
+            alias = AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
+        return alias
 
     def get_location_by_name(self, name) -> dict[str, Any]:
         location = self.location_table.get(name)
@@ -286,6 +289,7 @@ class ManualContext(SuperContext):
                         self.set_deathlink = True
                         self.last_death_link = 0
                     self.visible_events = args['slot_data'].get('visible_events', {})
+                    self.location_id_to_alias = args['slot_data'].get('location_id_to_alias', {})
                     logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -1125,8 +1125,11 @@ class ManualContext(SuperContext):
 
                     return
 
-                self.ctx.items_received.append("__Victory__")
-                self.ctx.syncing = True
+                if tracker_loaded and self.ctx.block_unreachable_location_press and "__Victory__" not in self.ctx.tracker_reachable_events:
+                    logger.debug(f"button for location '{button.text}' was pressed while unreachable")
+                else:
+                    self.ctx.items_received.append("__Victory__")
+                    self.ctx.syncing = True
 
         return ManualManager
 

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -836,7 +836,7 @@ class ManualContext(SuperContext):
                     category_scroll.add_widget(category_layout)
 
                     for location_id in self.listed_locations[location_category]:
-                        location_button = TreeViewButton(text=f"custom button text: {self.ctx.location_names.lookup_in_game(location_id)}", size_hint=(None, None), height=30, width=400)
+                        location_button = TreeViewButton(text=self.ctx.location_names.lookup_in_game(location_id), size_hint=(None, None), height=30, width=400)
                         location_button.bind(on_release=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
                         location_button.id = location_id
                         location_button.location_name = self.ctx.location_names.lookup_in_game(location_id)
@@ -848,7 +848,7 @@ class ManualContext(SuperContext):
                     if location_category in victory_categories:
                         # Add the Victory location to be marked at any point, which is why locations length has 1 added to it above
                         victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"]
-                        location_button = TreeViewButton(text=f"custom victory button text: {victory_text}", size_hint=(None, None), height=dp(30), width=dp(400))
+                        location_button = TreeViewButton(text=victory_text, size_hint=(None, None), height=dp(30), width=dp(400))
                         location_button.victory = True
                         location_button.location_name = victory_location["name"]
                         location_button.bind(on_release=self.victory_button_callback)

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -72,7 +72,7 @@ class SortingOrderCategories(IntEnum):
     inverted_natural = -2
     default = 2
 
-SortingOrderCategories.alphabetical.__doc__ = "Sort alphabetically using the name of item defined in locations.json."
+SortingOrderCategories.alphabetical.__doc__ = "Sort alphabetically using the name of the category."
 SortingOrderCategories.natural.__doc__ = "Sort like alphabetically but makes sure that any number are read as integer and thus sorted naturally. EG. key2 < key12"
 
 

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -222,15 +222,15 @@ class ManualContext(SuperContext):
         return Utils.persistent_load().get("client", {}).get("last_manual_game", None) or game_name
 
     def get_location_alias_by_id(self, id) -> str|None:
+        # First we try to get it from slotdata for dynamic aliases
         alias = self.location_id_to_alias.get(str(id), None)
-        # Kept a fallback if its not in slotdata
+        # Secondly we try to get it from the world itself for a more static alias
         if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
             alias = AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
         return alias
 
     def get_item_alias_by_id(self, id) -> str|None:
         alias = self.item_id_to_alias.get(str(id), None)
-        # Kept a fallback if its not in slotdata
         if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_alias"):
             alias = AutoWorldRegister.world_types[self.game].item_id_to_alias.get(id, None)
         return alias

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -809,10 +809,13 @@ class ManualContext(SuperContext):
                 tracker_panel = TreeView(root_options=dict(text="Items Received (%d)" % (items_length)), size_hint_y=None)
                 tracker_panel.bind(minimum_height=tracker_panel.setter('height'))
 
+                def category_sort_key(key: str):
+                    result = natural_sort_key(key)
+                    return [0 if key.lstrip().startswith("(") else 1] + result
                 # Sorting items categories
                 item_cat_sorting = SortingOrderCategories[self.ctx.items_categories_sorting]
                 if abs(item_cat_sorting) == SortingOrderCategories.natural:
-                    self.listed_items = {key: self.listed_items[key] for key in sorted(self.listed_items.keys(), key=natural_sort_key, reverse=item_cat_sorting < 0)}
+                    self.listed_items = {key: self.listed_items[key] for key in sorted(self.listed_items.keys(), key=category_sort_key, reverse=item_cat_sorting < 0)}
                 else:
                     self.listed_items = {key: self.listed_items[key] for key in sorted(self.listed_items.keys(), reverse=item_cat_sorting < 0)}
 
@@ -839,7 +842,7 @@ class ManualContext(SuperContext):
                 # Sorting location categories
                 loc_cat_sorting = SortingOrderCategories[self.ctx.locations_categories_sorting]
                 if abs(loc_cat_sorting) == SortingOrderCategories.natural:
-                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), key=natural_sort_key, reverse=loc_cat_sorting < 0)}
+                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), key=category_sort_key, reverse=loc_cat_sorting < 0)}
                 else:
                     self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), reverse=loc_cat_sorting < 0)}
 

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -384,7 +384,8 @@ class ManualContext(SuperContext):
 
         class TreeViewButton(Button, TreeViewNode):
             victory: bool = False
-            id: int = None
+            id: int|None = None
+            location_name: str = ""
 
         class TreeViewScrollView(ScrollView, TreeViewNode):
             pass
@@ -825,9 +826,10 @@ class ManualContext(SuperContext):
                     category_scroll.add_widget(category_layout)
 
                     for location_id in self.listed_locations[location_category]:
-                        location_button = TreeViewButton(text=self.ctx.location_names.lookup_in_game(location_id), size_hint=(None, None), height=30, width=400)
+                        location_button = TreeViewButton(text=f"custom button text: {self.ctx.location_names.lookup_in_game(location_id)}", size_hint=(None, None), height=30, width=400)
                         location_button.bind(on_release=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
                         location_button.id = location_id
+                        location_button.location_name = self.ctx.location_names.lookup_in_game(location_id)
                         category_layout.add_widget(location_button)
 
                     # if this is the category that Victory is in, display the Victory button
@@ -835,9 +837,10 @@ class ManualContext(SuperContext):
                     #     ("category" not in victory_location_data and location_category == "(No Category)"):
                     if location_category in victory_categories:
                         # Add the Victory location to be marked at any point, which is why locations length has 1 added to it above
-                        victory_text = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"]
-                        location_button = TreeViewButton(text=victory_text, size_hint=(None, None), height=dp(30), width=dp(400))
+                        victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"]
+                        location_button = TreeViewButton(text=f"custom victory button text: {victory_text}", size_hint=(None, None), height=dp(30), width=dp(400))
                         location_button.victory = True
+                        location_button.location_name = victory_location["name"]
                         location_button.bind(on_release=self.victory_button_callback)
                         category_layout.add_widget(location_button)
 
@@ -1061,7 +1064,7 @@ class ManualContext(SuperContext):
                                 for location_button in category_grid.children:
                                     if type(location_button) is TreeViewButton:
                                         # should only be true for the victory location button, which has different text
-                                        if location_button.text not in (self.ctx.location_table or AutoWorldRegister.world_types[self.ctx.game].location_name_to_location):
+                                        if location_button.victory:
                                             # if the player is searching for text and the location name doesn't contain it, hide and disable it
                                             if self.ctx.search_term and not self.ctx.search_term.lower() in location_button.text.lower():
                                                 hide_button_during_search(location_button)
@@ -1076,15 +1079,13 @@ class ManualContext(SuperContext):
                                                 continue
 
                                         if location_button.id and location_button.id not in self.ctx.missing_locations:
-                                            import logging
-
-                                            logging.info("location button being removed: " + location_button.text)
+                                            logger.info("location button being removed: " + location_button.text)
                                             buttons_to_remove.append(location_button)
                                             continue
 
                                         was_reachable = False
 
-                                        if location_button.text in self.ctx.tracker_reachable_locations:
+                                        if location_button.location_name in self.ctx.tracker_reachable_locations:
                                             location_button.background_color = self.ctx.colors['location_in_logic']
                                             was_reachable = True
                                         else:
@@ -1130,8 +1131,8 @@ class ManualContext(SuperContext):
 
                                 category_scrollview.size=(Window.width / 2, scrollview_height)
 
-            def location_button_callback(self, location_id, button):
-                if button.text not in self.ctx.location_names_to_id:
+            def location_button_callback(self, location_id: int, button: TreeViewButton):
+                if button.location_name not in self.ctx.location_names_to_id:
                     raise Exception("Locations were not loaded correctly. Please reconnect your client.")
 
                 # if the mouse is currently hovering over any of the controls/tabs at the top of the client, ignore clicks for location buttons underneath
@@ -1146,7 +1147,7 @@ class ManualContext(SuperContext):
                     return
 
                 if location_id:
-                    if tracker_loaded and self.ctx.block_unreachable_location_press and button.text not in self.ctx.tracker_reachable_locations:
+                    if tracker_loaded and self.ctx.block_unreachable_location_press and button.location_name not in self.ctx.tracker_reachable_locations:
                         logger.debug(f"button for location '{button.text}' was pressed while unreachable")
                     else:
                         self.ctx.locations_checked.append(location_id)
@@ -1156,7 +1157,7 @@ class ManualContext(SuperContext):
                     # message = [{"cmd": 'LocationChecks', "locations": [location_id]}]
                     # self.ctx.send_msgs(message)
 
-            def victory_button_callback(self, button):
+            def victory_button_callback(self, button: TreeViewButton):
                 # if the mouse is currently hovering over any of the controls/tabs at the top of the client, ignore clicks for location buttons underneath
                 if self.are_top_controls_at_mouse_pos():
                     # if there's an obj in the top controls/tab at the current mouse position, click it instead

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -72,8 +72,8 @@ class SortingOrderCategories(IntEnum):
     inverted_natural = -2
     default = 2
 
-SortingOrderLoc.alphabetical.__doc__ = "Sort alphabetically using the name of item defined in locations.json."
-SortingOrderLoc.natural.__doc__ = "Sort like alphabetically but makes sure that any number are read as integer and thus sorted naturally. EG. key2 < key12"
+SortingOrderCategories.alphabetical.__doc__ = "Sort alphabetically using the name of item defined in locations.json."
+SortingOrderCategories.natural.__doc__ = "Sort like alphabetically but makes sure that any number are read as integer and thus sorted naturally. EG. key2 < key12"
 
 
 @cache
@@ -552,6 +552,16 @@ class ManualContext(SuperContext):
                             self.ctx.locations_sorting = value
                             self.build_tracker_and_locations_table()
                             self.request_update_tracker_and_locations_table()
+                    elif key == "locations_categories_sorting_order":
+                        if value in SortingOrderCategories._member_names_:
+                            self.ctx.locations_categories_sorting = value
+                            self.build_tracker_and_locations_table()
+                            self.request_update_tracker_and_locations_table()
+                    elif key == "items_categories_sorting_order":
+                        if value in SortingOrderCategories._member_names_:
+                            self.ctx.items_categories_sorting = value
+                            self.build_tracker_and_locations_table()
+                            self.request_update_tracker_and_locations_table()
                 elif section == "universal-tracker":
                     if key == "block_unreachable_location_press":
                         self.ctx.block_unreachable_location_press = True if value == "Yes" else False
@@ -778,9 +788,9 @@ class ManualContext(SuperContext):
                 # Sorting items categories
                 item_cat_sorting = SortingOrderCategories[self.ctx.items_categories_sorting]
                 if abs(item_cat_sorting) == SortingOrderCategories.natural:
-                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), key=natural_sort_key, reverse=item_cat_sorting < 0)}
+                    self.listed_items = {key: self.listed_items[key] for key in sorted(self.listed_items.keys(), key=natural_sort_key, reverse=item_cat_sorting < 0)}
                 else:
-                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), reverse=item_cat_sorting < 0)}
+                    self.listed_items = {key: self.listed_items[key] for key in sorted(self.listed_items.keys(), reverse=item_cat_sorting < 0)}
 
                 # Since items_received is not available on connect, don't bother building item labels here
                 for item_category in self.listed_items.keys():
@@ -805,9 +815,9 @@ class ManualContext(SuperContext):
                 # Sorting location categories
                 loc_cat_sorting = SortingOrderCategories[self.ctx.locations_categories_sorting]
                 if abs(loc_cat_sorting) == SortingOrderCategories.natural:
-                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), key=natural_sort_key, reverse=loc_sorting < 0)}
+                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), key=natural_sort_key, reverse=loc_cat_sorting < 0)}
                 else:
-                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), reverse=loc_sorting < 0)}
+                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), reverse=loc_cat_sorting < 0)}
 
                 for location_category in self.listed_locations.keys():
                     locations_in_category = len(self.listed_locations[location_category])

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -65,6 +65,17 @@ SortingOrderItem.alphabetical.__doc__ = "Sort alphabetically using the name of i
 SortingOrderItem.natural.__doc__ = "Sort like custom but makes sure that any number are read as integer and thus sorted naturally. EG. key2 < key12"
 SortingOrderItem.received.__doc__ = "Sort the item in the order they are received from the server"
 
+class SortingOrderCategories(IntEnum):
+    alphabetical = 1
+    inverted_alphabetical = -1
+    natural = 2
+    inverted_natural = -2
+    default = 2
+
+SortingOrderLoc.alphabetical.__doc__ = "Sort alphabetically using the name of item defined in locations.json."
+SortingOrderLoc.natural.__doc__ = "Sort like alphabetically but makes sure that any number are read as integer and thus sorted naturally. EG. key2 < key12"
+
+
 @cache
 def strip_articles(title: str) -> str:
     lower = title.lower()
@@ -75,6 +86,14 @@ def strip_articles(title: str) -> str:
     elif lower.startswith("an "):
         title = title[3:]
     return title
+
+def natural_sort_key(key: str):
+    # Modified from https://stackoverflow.com/a/11150413
+    def convert(text):
+        return int(text) if text.isdigit() else text.lower()
+    key = strip_articles(key)
+
+    return [convert(c) for c in re.split('([0-9]+)', key)]
 
 class ManualClientCommandProcessor(ClientCommandProcessor):
     def _cmd_resync(self) -> bool:
@@ -121,18 +140,20 @@ class ManualContext(SuperContext):
     region_table = {}
     category_table = {}
 
-    tracker_reachable_locations = []
-    tracker_reachable_events = []
+    tracker_reachable_locations: list[str] = []
+    tracker_reachable_events: list[str] = []
 
     set_deathlink = False
     last_death_link = 0
     deathlink_out = False
 
-    visible_events = {}
+    visible_events: dict[str, dict[str, Any]]  = {}
 
     search_term = ""
     items_sorting = SortingOrderItem.default.name
+    items_categories_sorting = SortingOrderCategories.default.name
     locations_sorting = SortingOrderLoc.default.name
+    locations_categories_sorting = SortingOrderCategories.default.name
     block_unreachable_location_press = True
 
     colors = {
@@ -416,6 +437,8 @@ class ManualContext(SuperContext):
 
                 self.ctx.items_sorting = self.config.get('manual', 'items_sorting_order')
                 self.ctx.locations_sorting = self.config.get('manual', 'locations_sorting_order')
+                self.ctx.items_categories_sorting = self.config.get('manual', 'items_categories_sorting_order')
+                self.ctx.locations_categories_sorting = self.config.get('manual', 'locations_categories_sorting_order')
                 self.ctx.block_unreachable_location_press = True if self.config.get('universal-tracker', 'block_unreachable_location_press') == "Yes" else False
 
                 self.manual_game_layout = BoxLayout(orientation="horizontal", size_hint_y=None, height=dp(30))
@@ -450,7 +473,9 @@ class ManualContext(SuperContext):
                 super().build_config(config)
                 config.setdefaults("manual", {
                     "items_sorting_order": SortingOrderItem.default.name,
-                    "locations_sorting_order": SortingOrderLoc.default.name
+                    "locations_sorting_order": SortingOrderLoc.default.name,
+                    "items_categories_sorting_order": SortingOrderCategories.default.name,
+                    "locations_categories_sorting_order": SortingOrderCategories.default.name
                 })
                 config.setdefaults("universal-tracker", {
                     "block_unreachable_location_press": "Yes"
@@ -479,6 +504,22 @@ class ManualContext(SuperContext):
                             "key": "locations_sorting_order",
                             "options": list(SortingOrderLoc._member_names_),
                             "desc": "\n".join([f'[b]{i.name}/inverted_{i.name}[/b]: {i.__doc__}' for i in SortingOrderLoc if i.__doc__ is not None])
+                        },
+                        {
+                            "type": "options",
+                            "title": "Items Category Sorting Order",
+                            "section": "manual",
+                            "key": "items_categories_sorting_order",
+                            "options": list(SortingOrderCategories._member_names_),
+                            "desc": '\n'.join([f'[b]{i.name}/inverted_{i.name}[/b]: {i.__doc__}' for i in SortingOrderCategories if i.__doc__ is not None])
+                        },
+                        {
+                            "type": "options",
+                            "title": "Locations Sorting Order",
+                            "section": "manual",
+                            "key": "locations_categories_sorting_order",
+                            "options": list(SortingOrderCategories._member_names_),
+                            "desc": "Same Options as Items Category Sorting Order."
                         },
                     ]
                 if tracker_loaded:
@@ -722,15 +763,8 @@ class ManualContext(SuperContext):
                             reverse=loc_sorting < 0)
 
                 elif abs(loc_sorting) == SortingOrderLoc.natural:
-                    # Modified from https://stackoverflow.com/a/11150413
-                    def convert(text):
-                        return int(text) if text.isdigit() else text.lower()
-
-                    def alphanum_key(i):
-                        name = strip_articles(self.ctx.get_location_by_id(i).get("name", ""))
-
-                        return [convert(c) for c in re.split('([0-9]+)', self.ctx.get_location_by_id(i).get("sort-key", name))]
-
+                    def alphanum_key(key: int) -> list[str|int]:
+                        return natural_sort_key(self.ctx.get_location_by_id(key).get("sort-key",self.ctx.get_location_by_id(key).get("name", "")))
                     for category in self.listed_locations:
                         self.listed_locations[category].sort(key=alphanum_key, reverse=loc_sorting < 0)
 
@@ -740,8 +774,15 @@ class ManualContext(SuperContext):
                 tracker_panel = TreeView(root_options=dict(text="Items Received (%d)" % (items_length)), size_hint_y=None)
                 tracker_panel.bind(minimum_height=tracker_panel.setter('height'))
 
+                # Sorting items categories
+                item_cat_sorting = SortingOrderCategories[self.ctx.items_categories_sorting]
+                if abs(item_cat_sorting) == SortingOrderCategories.natural:
+                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), key=natural_sort_key, reverse=item_cat_sorting < 0)}
+                else:
+                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), reverse=item_cat_sorting < 0)}
+
                 # Since items_received is not available on connect, don't bother building item labels here
-                for item_category in sorted(self.listed_items.keys()):
+                for item_category in self.listed_items.keys():
                     category_tree = tracker_panel.add_node(
                         TreeViewLabel(text = "%s (%s)" % (item_category, len(self.listed_items[item_category])))
                     )
@@ -760,7 +801,14 @@ class ManualContext(SuperContext):
                 if not self.ctx.location_table and not hasattr(AutoWorldRegister.world_types[self.ctx.game], 'location_name_to_location'):
                     raise Exception("The apworld for %s is too outdated for this client. Please update it." % (self.ctx.game))
 
-                for location_category in sorted(self.listed_locations.keys()):
+                # Sorting location categories
+                loc_cat_sorting = SortingOrderCategories[self.ctx.locations_categories_sorting]
+                if abs(loc_cat_sorting) == SortingOrderCategories.natural:
+                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), key=natural_sort_key, reverse=loc_sorting < 0)}
+                else:
+                    self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), reverse=loc_sorting < 0)}
+
+                for location_category in self.listed_locations.keys():
                     locations_in_category = len(self.listed_locations[location_category])
 
                     if (location_category in victory_categories) or \
@@ -910,14 +958,9 @@ class ManualContext(SuperContext):
                                     reverse=item_sorting < 0)
 
                                 elif abs(item_sorting) == SortingOrderItem.natural:
-                                    def convert(text):
-                                        return int(text) if text.isdigit() else text.lower()
-                                    def alphanum_key(i):
-                                        name = self.ctx.get_item_by_id(i).get("name", "")
-                                        name = strip_articles(name)
+                                    def alphanum_key(key: int) -> list[str|int]:
+                                        return natural_sort_key(self.ctx.get_item_by_id(key).get("sort-key", self.ctx.get_item_by_id(key).get("name", "")))
 
-                                        return [convert(c) for c in re.split('([0-9]+)',self.ctx.get_item_by_id(i).get("sort-key", name))
-                                                                                ]
                                     sorted_items_received = sorted(sorted_items_received, key=alphanum_key, reverse=item_sorting < 0)
 
                                 elif abs(item_sorting) == SortingOrderItem.received:

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -149,6 +149,7 @@ class ManualContext(SuperContext):
 
     visible_events: dict[str, dict[str, Any]]  = {}
     location_id_to_alias: dict[str, str] = {}
+    item_id_to_alias: dict[str, str] = {}
 
     search_term = ""
     items_sorting = SortingOrderItem.default.name
@@ -220,11 +221,18 @@ class ManualContext(SuperContext):
         from .Game import game_name  # This will at least give us the name of a manual they've installed
         return Utils.persistent_load().get("client", {}).get("last_manual_game", game_name)
 
-    def get_location_UT_alias_by_id(self, id) -> str|None:
+    def get_location_alias_by_id(self, id) -> str|None:
         alias = self.location_id_to_alias.get(str(id), None)
         # Kept a fallback if its not in slotdata
         if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
             alias = AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
+        return alias
+
+    def get_item_alias_by_id(self, id) -> str|None:
+        alias = self.item_id_to_alias.get(str(id), None)
+        # Kept a fallback if its not in slotdata
+        if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_alias"):
+            alias = AutoWorldRegister.world_types[self.game].item_id_to_alias.get(id, None)
         return alias
 
     def get_location_by_name(self, name) -> dict[str, Any]:
@@ -290,6 +298,7 @@ class ManualContext(SuperContext):
                         self.last_death_link = 0
                     self.visible_events = args['slot_data'].get('visible_events', {})
                     self.location_id_to_alias = args['slot_data'].get('location_id_to_alias', {})
+                    self.item_id_to_alias = args['slot_data'].get('item_id_to_alias', {})
                     logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()
@@ -395,6 +404,12 @@ class ManualContext(SuperContext):
             victory: bool = False
             id: int|None = None
             location_name: str = ""
+
+        class ItemLabel(Label):
+            item_id: int|None = None
+            item_count: int = 1
+            item_name: str = ""
+            item_alias: str = ""
 
         class TreeViewScrollView(ScrollView, TreeViewNode):
             pass
@@ -845,7 +860,7 @@ class ManualContext(SuperContext):
                     category_scroll.add_widget(category_layout)
 
                     for location_id in self.listed_locations[location_category]:
-                        extra = f' ({alias})' if (alias := self.ctx.get_location_UT_alias_by_id(location_id)) is not None else ''
+                        extra = f' ({alias})' if (alias := self.ctx.get_location_alias_by_id(location_id)) is not None else ''
                         text = f"{self.ctx.location_names.lookup_in_game(location_id)}{extra}"
                         location_button = TreeViewButton(text=text, size_hint=(None, None), height=30, width=400)
                         location_button.bind(on_release=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
@@ -858,7 +873,7 @@ class ManualContext(SuperContext):
                     #     ("category" not in victory_location_data and location_category == "(No Category)"):
                     if location_category in victory_categories:
                         # Add the Victory location to be marked at any point, which is why locations length has 1 added to it above
-                        extra = f' ({alias})' if (alias := self.ctx.get_location_UT_alias_by_id(victory_location["id"])) is not None else ''
+                        extra = f' ({alias})' if (alias := self.ctx.get_location_alias_by_id(victory_location["id"])) is not None else ''
                         victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"] + extra
                         location_button = TreeViewButton(text=victory_text, size_hint=(None, None), height=dp(30), width=dp(400))
                         location_button.victory = True
@@ -931,11 +946,11 @@ class ManualContext(SuperContext):
 
                                 # for items that were already listed, determine if the qty changed. if it did, add them to the list to be bolded
                                 for item in category_grid.children:
-                                    if type(item) is Label:
+                                    if type(item) is ItemLabel:
                                         # Get the item name from the item Label, minus quantity, then do a lookup for count
-                                        old_item_text = item.text
-                                        item_name = re.sub(r"\s\(\d+\)$", "", item.text)
-                                        item_id = self.ctx.item_names_to_id.get(item_name, False)
+                                        old_count = item.item_count
+                                        item_name = item.item_name
+                                        item_id = item.item_id
                                         if item_id:
                                             item_count = len(list(i for i in self.ctx.items_received if i.item == item_id))
                                         else:
@@ -956,10 +971,11 @@ class ManualContext(SuperContext):
                                                 category_unique_name_count += 1
 
                                         # Update the label quantity
-                                        item.text="%s (%s)" % (item_name, item_count)
-
-                                        if update_highlights and (old_item_text != item.text):
+                                        if update_highlights and (old_count != item_count):
                                             bold_item_labels.append(item_name)
+                                            item.item_count = item_count
+
+                                        item.text="%s %s(%s)" % (item_name, item.item_alias, item_count)
 
                                         existing_item_labels.append(item_name)
 
@@ -1005,8 +1021,13 @@ class ManualContext(SuperContext):
 
                                     if category_name in item_data["category"] and network_item not in self.listed_items[category_name]:
                                         item_count = len(list(i for i in self.ctx.items_received if i.item == network_item))
-                                        item_text = Label(text="%s (%s)" % (item_name, item_count),
+                                        alias = f'({alias}) ' if (alias := self.ctx.get_item_alias_by_id(network_item)) is not None else ''
+                                        item_text = ItemLabel(text="%s %s(%s)" % (item_name, alias, item_count),
                                                     size_hint=(None, None), height=dp(30), width=dp(400), bold=True)
+                                        item_text.item_name = item_name
+                                        item_text.item_count = item_count
+                                        item_text.item_id = network_item
+                                        item_text.item_alias = alias
 
                                         # if the item was previously listed and was bold, or if it wasn't previously listed at all, make it bold
                                         item_text.bold = (update_highlights and (item_name in bold_item_labels or item_name not in existing_item_labels))
@@ -1020,8 +1041,10 @@ class ManualContext(SuperContext):
                                 for event in sorted(self.ctx.tracker_reachable_events):
                                     if self.ctx.is_event_visible(event, category_name) and event not in self.listed_items[category_name]:
                                         item_count = len(list(i for i in self.ctx.tracker_reachable_events if i == event))
-                                        item_text = Label(text="%s (%s)" % (event, item_count),
+                                        item_text = ItemLabel(text="%s (%s)" % (event, item_count),
                                                     size_hint=(None, None), height=dp(30), width=dp(400), bold=True)
+                                        item_text.item_name = event
+                                        item_text.item_count = item_count
                                         category_grid.add_widget(item_text)
                                         self.listed_items[category_name].append(event)
                                         category_count += item_count

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -858,7 +858,8 @@ class ManualContext(SuperContext):
                     #     ("category" not in victory_location_data and location_category == "(No Category)"):
                     if location_category in victory_categories:
                         # Add the Victory location to be marked at any point, which is why locations length has 1 added to it above
-                        victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"]
+                        extra = f' ({alias})' if (alias := self.ctx.get_location_UT_alias_by_id(victory_location["id"])) is not None else ''
+                        victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"] + extra
                         location_button = TreeViewButton(text=victory_text, size_hint=(None, None), height=dp(30), width=dp(400))
                         location_button.victory = True
                         location_button.location_name = victory_location["name"]

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -148,8 +148,6 @@ class ManualContext(SuperContext):
     deathlink_out = False
 
     visible_events: dict[str, dict[str, Any]]  = {}
-    location_id_to_alias: dict[str, str] = {}
-    item_id_to_alias: dict[str, str] = {}
 
     search_term = ""
     items_sorting = SortingOrderItem.default.name
@@ -221,20 +219,6 @@ class ManualContext(SuperContext):
         from .Game import game_name  # This will at least give us the name of a manual they've installed
         return Utils.persistent_load().get("client", {}).get("last_manual_game", None) or game_name
 
-    def get_location_alias_by_id(self, id) -> str|None:
-        # First we try to get it from slotdata for dynamic aliases
-        alias = self.location_id_to_alias.get(str(id), None)
-        # Secondly we try to get it from the world itself for a more static alias
-        if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
-            alias = AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
-        return alias
-
-    def get_item_alias_by_id(self, id) -> str|None:
-        alias = self.item_id_to_alias.get(str(id), None)
-        if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_alias"):
-            alias = AutoWorldRegister.world_types[self.game].item_id_to_alias.get(id, None)
-        return alias
-
     def get_location_by_name(self, name) -> dict[str, Any]:
         location = self.location_table.get(name)
         if not location:
@@ -297,8 +281,6 @@ class ManualContext(SuperContext):
                         self.set_deathlink = True
                         self.last_death_link = 0
                     self.visible_events = args['slot_data'].get('visible_events', {})
-                    self.location_id_to_alias = args['slot_data'].get('location_id_to_alias', {})
-                    self.item_id_to_alias = args['slot_data'].get('item_id_to_alias', {})
                     logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()
@@ -409,7 +391,6 @@ class ManualContext(SuperContext):
             item_id: int|None = None
             item_count: int = 1
             item_name: str = ""
-            item_alias: str = ""
 
         class TreeViewScrollView(ScrollView, TreeViewNode):
             pass
@@ -883,8 +864,7 @@ class ManualContext(SuperContext):
                     for location_id in self.listed_locations[location_category]:
                         has_hint = location_id in hinted_locations or location_id in scoutable_locations
 
-                        extra = f' ({alias})' if (alias := self.ctx.get_location_alias_by_id(location_id)) is not None else ''
-                        text = f"{self.ctx.location_names.lookup_in_game(location_id)}{extra}"
+                        text = f"{self.ctx.location_names.lookup_in_game(location_id)}"
                         location_button = TreeViewButton(text=text, size_hint=(.75 if has_hint else 1, None), height=30)
                         location_button.bind(on_release=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
                         location_button.id = location_id
@@ -907,8 +887,7 @@ class ManualContext(SuperContext):
                     #     ("category" not in victory_location_data and location_category == "(No Category)"):
                     if location_category in victory_categories:
                         # Add the Victory location to be marked at any point, which is why locations length has 1 added to it above
-                        extra = f' ({alias})' if (alias := self.ctx.get_location_alias_by_id(victory_location["id"])) is not None else ''
-                        victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"] + extra
+                        victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"]
                         location_button = TreeViewButton(text=victory_text, size_hint=(1, None), height=dp(30), width=dp(400))
                         location_button.victory = True
                         location_button.location_name = victory_location["name"]
@@ -1009,7 +988,7 @@ class ManualContext(SuperContext):
                                             bold_item_labels.append(item_name)
                                             item.item_count = item_count
 
-                                        item.text="%s %s(%s)" % (item_name, item.item_alias, item_count)
+                                        item.text="%s (%s)" % (item_name, item_count)
 
                                         existing_item_labels.append(item_name)
 
@@ -1055,13 +1034,11 @@ class ManualContext(SuperContext):
 
                                     if category_name in item_data["category"] and network_item not in self.listed_items[category_name]:
                                         item_count = len(list(i for i in self.ctx.items_received if i.item == network_item))
-                                        alias = f'({alias}) ' if (alias := self.ctx.get_item_alias_by_id(network_item)) is not None else ''
-                                        item_text = ItemLabel(text="%s %s(%s)" % (item_name, alias, item_count),
+                                        item_text = ItemLabel(text="%s (%s)" % (item_name, item_count),
                                                     size_hint=(None, None), height=dp(30), width=dp(400), bold=True)
                                         item_text.item_name = item_name
                                         item_text.item_count = item_count
                                         item_text.item_id = network_item
-                                        item_text.item_alias = alias
 
                                         # if the item was previously listed and was bold, or if it wasn't previously listed at all, make it bold
                                         item_text.bold = (update_highlights and (item_name in bold_item_labels or item_name not in existing_item_labels))

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -153,9 +153,9 @@ class ManualContext(SuperContext):
 
     search_term = ""
     items_sorting = SortingOrderItem.default.name
-    items_categories_sorting = SortingOrderCategories.default.name
+    item_categories_sorting = SortingOrderCategories.default.name
     locations_sorting = SortingOrderLoc.default.name
-    locations_categories_sorting = SortingOrderCategories.default.name
+    location_categories_sorting = SortingOrderCategories.default.name
     block_unreachable_location_press = True
 
     colors = {
@@ -462,8 +462,8 @@ class ManualContext(SuperContext):
 
                 self.ctx.items_sorting = self.config.get('manual', 'items_sorting_order')
                 self.ctx.locations_sorting = self.config.get('manual', 'locations_sorting_order')
-                self.ctx.items_categories_sorting = self.config.get('manual', 'items_categories_sorting_order')
-                self.ctx.locations_categories_sorting = self.config.get('manual', 'locations_categories_sorting_order')
+                self.ctx.item_categories_sorting = self.config.get('manual', 'item_categories_sorting_order')
+                self.ctx.location_categories_sorting = self.config.get('manual', 'location_categories_sorting_order')
                 self.ctx.block_unreachable_location_press = True if self.config.get('universal-tracker', 'block_unreachable_location_press') == "Yes" else False
 
                 self.manual_game_layout = BoxLayout(orientation="horizontal", size_hint_y=None, height=dp(30))
@@ -499,8 +499,8 @@ class ManualContext(SuperContext):
                 config.setdefaults("manual", {
                     "items_sorting_order": SortingOrderItem.default.name,
                     "locations_sorting_order": SortingOrderLoc.default.name,
-                    "items_categories_sorting_order": SortingOrderCategories.default.name,
-                    "locations_categories_sorting_order": SortingOrderCategories.default.name
+                    "item_categories_sorting_order": SortingOrderCategories.default.name,
+                    "location_categories_sorting_order": SortingOrderCategories.default.name
                 })
                 config.setdefaults("universal-tracker", {
                     "block_unreachable_location_press": "Yes"
@@ -532,17 +532,17 @@ class ManualContext(SuperContext):
                         },
                         {
                             "type": "options",
-                            "title": "Items Category Sorting Order",
+                            "title": "Item Categories Sorting Order",
                             "section": "manual",
-                            "key": "items_categories_sorting_order",
+                            "key": "item_categories_sorting_order",
                             "options": list(SortingOrderCategories._member_names_),
                             "desc": '\n'.join([f'[b]{i.name}/inverted_{i.name}[/b]: {i.__doc__}' for i in SortingOrderCategories if i.__doc__ is not None])
                         },
                         {
                             "type": "options",
-                            "title": "Locations Sorting Order",
+                            "title": "Location Categories Sorting Order",
                             "section": "manual",
-                            "key": "locations_categories_sorting_order",
+                            "key": "location_categories_sorting_order",
                             "options": list(SortingOrderCategories._member_names_),
                             "desc": "Same Options as Items Category Sorting Order."
                         },
@@ -576,14 +576,14 @@ class ManualContext(SuperContext):
                             self.ctx.locations_sorting = value
                             self.build_tracker_and_locations_table()
                             self.request_update_tracker_and_locations_table()
-                    elif key == "locations_categories_sorting_order":
+                    elif key == "location_categories_sorting_order":
                         if value in SortingOrderCategories._member_names_:
-                            self.ctx.locations_categories_sorting = value
+                            self.ctx.location_categories_sorting = value
                             self.build_tracker_and_locations_table()
                             self.request_update_tracker_and_locations_table()
-                    elif key == "items_categories_sorting_order":
+                    elif key == "item_categories_sorting_order":
                         if value in SortingOrderCategories._member_names_:
-                            self.ctx.items_categories_sorting = value
+                            self.ctx.item_categories_sorting = value
                             self.build_tracker_and_locations_table()
                             self.request_update_tracker_and_locations_table()
                 elif section == "universal-tracker":
@@ -831,7 +831,7 @@ class ManualContext(SuperContext):
                     result = natural_sort_key(key)
                     return [0 if key.lstrip().startswith("(") else 1] + result
                 # Sorting items categories
-                item_cat_sorting = SortingOrderCategories[self.ctx.items_categories_sorting]
+                item_cat_sorting = SortingOrderCategories[self.ctx.item_categories_sorting]
                 if abs(item_cat_sorting) == SortingOrderCategories.natural:
                     self.listed_items = {key: self.listed_items[key] for key in sorted(self.listed_items.keys(), key=category_sort_key, reverse=item_cat_sorting < 0)}
                 else:
@@ -858,7 +858,7 @@ class ManualContext(SuperContext):
                     raise Exception("The apworld for %s is too outdated for this client. Please update it." % (self.ctx.game))
 
                 # Sorting location categories
-                loc_cat_sorting = SortingOrderCategories[self.ctx.locations_categories_sorting]
+                loc_cat_sorting = SortingOrderCategories[self.ctx.location_categories_sorting]
                 if abs(loc_cat_sorting) == SortingOrderCategories.natural:
                     self.listed_locations = {key: self.listed_locations[key] for key in sorted(self.listed_locations.keys(), key=category_sort_key, reverse=loc_cat_sorting < 0)}
                 else:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -72,6 +72,7 @@ class ManualWorld(World):
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True
     location_id_to_alias: dict[int, str] = {}
+    item_id_to_alias: dict[int, str] = {}
 
     origin_region_name = "Manual"
 
@@ -423,8 +424,6 @@ class ManualWorld(World):
             if option_key in common_options:
                 continue
             slot_data[option_key] = get_option_value(self.multiworld, self.player, option_key)
-
-        slot_data["location_id_to_alias"] = self.location_id_to_alias
 
         slot_data["visible_events"] = {}
         for _, event in self.event_name_to_event.items():

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -570,7 +570,7 @@ class VersionedComponent(Component):
         self.version = version
 
 def add_client_to_launcher() -> None:
-    version = 2026_03_19 # YYYYMMDD
+    version = 2026_04_07 # YYYYMMDD
     found = False
 
     if "manual" not in icon_paths:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -71,6 +71,7 @@ class ManualWorld(World):
 
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True
+    location_id_to_alias: dict[int, str] = {}
 
     origin_region_name = "Manual"
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -418,10 +418,13 @@ class ManualWorld(World):
 
         # slot_data["DeathLink"] = bool(self.multiworld.death_link[self.player].value)
         common_options = set(PerGameCommonOptions.type_hints.keys())
+        common_options |= set(["generate_region_diagram", "start_inventory_from_pool"])
         for option_key, _ in self.options_dataclass.type_hints.items():
             if option_key in common_options:
                 continue
             slot_data[option_key] = get_option_value(self.multiworld, self.player, option_key)
+
+        slot_data["location_id_to_alias"] = self.location_id_to_alias
 
         slot_data["visible_events"] = {}
         for _, event in self.event_name_to_event.items():

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -71,9 +71,6 @@ class ManualWorld(World):
 
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True
-    location_id_to_alias: dict[int, str] = {}
-    item_id_to_alias: dict[int, str] = {}
-
     origin_region_name = "Manual"
 
     def get_filler_item_name(self) -> str:


### PR DESCRIPTION
like my #201 PR this pr make some misc changes but to the client this time
things included in this PR so far:
- Add the missing Click protection to the victory button
- Add Settings to sort the categories via Natural sort and/or reversed order if thats what the player wants
  - Done via 2 new settings in the F1 menu (see second screenshot)
  - Default is set to Natural
- Made location buttons check their state via a new button.location_name for UT checks and location sending
  - This is a preparation for a future PR where we can add support for location aliases either by supporting UT own alias system or from our own system (or a mix of both)
- Similarly to locations I made items use a custom label that saves their name inside of a property instead of their text
- Searches still use the button text so filtering will work with the potential future extra text
<img width="891" height="162" alt="image" src="https://github.com/user-attachments/assets/e382cb2e-dd7e-458e-897a-a95f81ba7451" />


<details><summary>Alias stuff was moved to other branch on silasary's request but the old changelog are still here</summary>
<p>
  - I added some basic support for UT's alias system that visually added some text next to the location name (see third screenshot)
    - the support is Hook only currently but a bigger PR could probably make this better
  - This let met add an equivalent to the location's alias system (which is not a thing in UT but it fit in our client)
The following example pictures shows my Old OuterWilds manual using those aliases to protect against spoilers
<img width="1169" height="124" alt="image" src="https://github.com/user-attachments/assets/d25e851b-8578-4035-87d2-124c098ad7bc" />
</p>
</details> 

