### PR TITLE
Allow people to use the name of an existing item for their automatic filler.

### DIFF
--- a/src/Items.py
+++ b/src/Items.py
@@ -15,11 +15,7 @@ lastItemId = -1
 
 count = starting_index
 
-# add the filler item to the list of items for lookup
-if filler_item_name:
-    item_table.append({
-        "name": filler_item_name
-    })
+filler_found = False
 
 # add sequential generated ids to the lists
 for key, val in enumerate(item_table):
@@ -34,7 +30,17 @@ for key, val in enumerate(item_table):
     item_table[key]["progression"] = val["progression"] if "progression" in val else False
     if isinstance(val.get("category", []), str):
         item_table[key]["category"] = [val["category"]]
+    if item_table[key].get("name") == filler_item_name:
+        filler_found = True
 
+    count += 1
+
+# add the filler item to the list of items for lookup
+if filler_item_name and not filler_found:
+    item_table.append({
+        "name": filler_item_name,
+        "id": count,
+    })
     count += 1
 
 for item in item_table:


### PR DESCRIPTION
People have long desired the ability to add a category to the automatic filler.  So far, that's only been possible with hooks.



This refactors the code a bit, so that we can take the name of an existing item in the `filler\_item\_name`, which will allow for better customization.

