### PR TITLE
Item/location description in the client

### DIFF
--- a/schemas/Manual.items.schema.json
+++ b/schemas/Manual.items.schema.json
@@ -116,6 +116,10 @@
                     "description": "(Optional) A string to sort the items by. If not provided, items will always be sorted by name.",
                     "type": "string"
                 },
+                "description": {
+                    "description": "(Optional) A short description of the item to be displayed in the client",
+                    "type": "string"
+                },
                 "_comment": {"$ref": "#/definitions/comment"}
             },
             "required": ["name"]

--- a/schemas/Manual.locations.schema.json
+++ b/schemas/Manual.locations.schema.json
@@ -104,6 +104,10 @@
                     "description": "(Optional) A string to sort the locations by. If not provided, locations will always be sorted by name.",
                     "type": "string"
                 },
+                "description": {
+                    "description": "(Optional) A short description of the location to be displayed in the client in the Manual and Tracker tabs",
+                    "type": "string"
+                },
                 "_comment": {"$ref": "#/definitions/comment"}
             },
             "required": ["name"]

--- a/src/Items.py
+++ b/src/Items.py
@@ -8,8 +8,8 @@ from .Game import filler_item_name, starting_index, game_name
 ######################
 
 item_id_to_name: dict[int, str] = {}
-item_id_to_description: dict[int, str] = {}
 item_name_to_item: dict[str, dict] = {}
+item_name_to_description: dict[str, str] = {}
 item_name_groups: dict[str, str] = {}
 advancement_item_names: set[str] = set()
 lastItemId = -1
@@ -39,7 +39,7 @@ for key, val in enumerate(item_table):
     count += 1
 
 for item in item_table:
-    item_name = item.get("name", f"Unnamed Item {item['id']}")
+    item_name: str = item.get("name", f"Unnamed Item {item['id']}")
     item_id_to_name[item["id"]] = item_name
     item_name_to_item[item_name] = item
 
@@ -62,7 +62,7 @@ for item in item_table:
         item_name_groups[group_name].append(item_name)
 
     if item.get("description"):
-        item_id_to_description[item["id"]] = item["description"]
+        item_name_to_description[item_name] = item["description"]
 
 item_id_to_name[None] = "__Victory__"
 item_name_to_id = {name: id for id, name in item_id_to_name.items()}

--- a/src/Items.py
+++ b/src/Items.py
@@ -8,6 +8,7 @@ from .Game import filler_item_name, starting_index, game_name
 ######################
 
 item_id_to_name: dict[int, str] = {}
+item_id_to_description: dict[int, str] = {}
 item_name_to_item: dict[str, dict] = {}
 item_name_groups: dict[str, str] = {}
 advancement_item_names: set[str] = set()
@@ -59,6 +60,9 @@ for item in item_table:
         if group_name not in item_name_groups:
             item_name_groups[group_name] = []
         item_name_groups[group_name].append(item_name)
+
+    if item.get("description"):
+        item_id_to_description[item["id"]] = item["description"]
 
 item_id_to_name[None] = "__Victory__"
 item_name_to_id = {name: id for id, name in item_id_to_name.items()}

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -45,13 +45,13 @@ if not victory_names:
     victory_names.append("__Manual Game Complete__")
 
 location_id_to_name: dict[int, str] = {}
-location_id_to_description: dict[int, str] = {}
 location_name_to_location: dict[str, dict[str, Any]] = {}
+location_name_to_description: dict[str, str] = {}
 location_name_groups: dict[str, list[str]] = {}
 event_name_to_event: dict[str, dict[str, Any]] = {}
 
 for loc in location_table:
-    loc_name = loc.get("name", f"Unnamed Location {loc['id']}")
+    loc_name: str = loc.get("name", f"Unnamed Location {loc['id']}")
     location_id_to_name[loc["id"]] = loc_name
     location_name_to_location[loc_name] = loc
 
@@ -61,7 +61,7 @@ for loc in location_table:
         location_name_groups[c].append(loc_name)
 
     if loc.get("description"):
-        location_id_to_description[loc["id"]] = loc["description"]
+        location_name_to_description[loc_name] = loc["description"]
 
 # location_id_to_name[None] = "__Manual Game Complete__"
 location_name_to_id = {name: id for id, name in location_id_to_name.items()}

--- a/src/Locations.py
+++ b/src/Locations.py
@@ -45,6 +45,7 @@ if not victory_names:
     victory_names.append("__Manual Game Complete__")
 
 location_id_to_name: dict[int, str] = {}
+location_id_to_description: dict[int, str] = {}
 location_name_to_location: dict[str, dict[str, Any]] = {}
 location_name_groups: dict[str, list[str]] = {}
 event_name_to_event: dict[str, dict[str, Any]] = {}
@@ -59,6 +60,8 @@ for loc in location_table:
             location_name_groups[c] = []
         location_name_groups[c].append(loc_name)
 
+    if loc.get("description"):
+        location_id_to_description[loc["id"]] = loc["description"]
 
 # location_id_to_name[None] = "__Manual Game Complete__"
 location_name_to_id = {name: id for id, name in location_id_to_name.items()}

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -148,6 +148,8 @@ class ManualContext(SuperContext):
     deathlink_out = False
 
     visible_events: dict[str, dict[str, Any]]  = {}
+    location_id_to_alias: dict[str, str] = {}
+    item_id_to_alias: dict[str, str] = {}
 
     search_term = ""
     items_sorting = SortingOrderItem.default.name
@@ -219,6 +221,20 @@ class ManualContext(SuperContext):
         from .Game import game_name  # This will at least give us the name of a manual they've installed
         return Utils.persistent_load().get("client", {}).get("last_manual_game", None) or game_name
 
+    def get_location_alias_by_id(self, id) -> str|None:
+        # First we try to get it from slotdata for dynamic aliases
+        alias = self.location_id_to_alias.get(str(id), None)
+        # Secondly we try to get it from the world itself for a more static alias
+        if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
+            alias = AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
+        return alias
+
+    def get_item_alias_by_id(self, id) -> str|None:
+        alias = self.item_id_to_alias.get(str(id), None)
+        if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_alias"):
+            alias = AutoWorldRegister.world_types[self.game].item_id_to_alias.get(id, None)
+        return alias
+
     def get_location_by_name(self, name) -> dict[str, Any]:
         location = self.location_table.get(name)
         if not location:
@@ -281,6 +297,8 @@ class ManualContext(SuperContext):
                         self.set_deathlink = True
                         self.last_death_link = 0
                     self.visible_events = args['slot_data'].get('visible_events', {})
+                    self.location_id_to_alias = args['slot_data'].get('location_id_to_alias', {})
+                    self.item_id_to_alias = args['slot_data'].get('item_id_to_alias', {})
                     logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()
@@ -391,6 +409,7 @@ class ManualContext(SuperContext):
             item_id: int|None = None
             item_count: int = 1
             item_name: str = ""
+            item_alias: str = ""
 
         class TreeViewScrollView(ScrollView, TreeViewNode):
             pass
@@ -864,7 +883,8 @@ class ManualContext(SuperContext):
                     for location_id in self.listed_locations[location_category]:
                         has_hint = location_id in hinted_locations or location_id in scoutable_locations
 
-                        text = f"{self.ctx.location_names.lookup_in_game(location_id)}"
+                        extra = f' ({alias})' if (alias := self.ctx.get_location_alias_by_id(location_id)) is not None else ''
+                        text = f"{self.ctx.location_names.lookup_in_game(location_id)}{extra}"
                         location_button = TreeViewButton(text=text, size_hint=(.75 if has_hint else 1, None), height=30)
                         location_button.bind(on_release=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
                         location_button.id = location_id
@@ -887,7 +907,8 @@ class ManualContext(SuperContext):
                     #     ("category" not in victory_location_data and location_category == "(No Category)"):
                     if location_category in victory_categories:
                         # Add the Victory location to be marked at any point, which is why locations length has 1 added to it above
-                        victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"]
+                        extra = f' ({alias})' if (alias := self.ctx.get_location_alias_by_id(victory_location["id"])) is not None else ''
+                        victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"] + extra
                         location_button = TreeViewButton(text=victory_text, size_hint=(1, None), height=dp(30), width=dp(400))
                         location_button.victory = True
                         location_button.location_name = victory_location["name"]
@@ -988,7 +1009,7 @@ class ManualContext(SuperContext):
                                             bold_item_labels.append(item_name)
                                             item.item_count = item_count
 
-                                        item.text="%s (%s)" % (item_name, item_count)
+                                        item.text="%s %s(%s)" % (item_name, item.item_alias, item_count)
 
                                         existing_item_labels.append(item_name)
 
@@ -1034,11 +1055,13 @@ class ManualContext(SuperContext):
 
                                     if category_name in item_data["category"] and network_item not in self.listed_items[category_name]:
                                         item_count = len(list(i for i in self.ctx.items_received if i.item == network_item))
-                                        item_text = ItemLabel(text="%s (%s)" % (item_name, item_count),
+                                        alias = f'({alias}) ' if (alias := self.ctx.get_item_alias_by_id(network_item)) is not None else ''
+                                        item_text = ItemLabel(text="%s %s(%s)" % (item_name, alias, item_count),
                                                     size_hint=(None, None), height=dp(30), width=dp(400), bold=True)
                                         item_text.item_name = item_name
                                         item_text.item_count = item_count
                                         item_text.item_id = network_item
+                                        item_text.item_alias = alias
 
                                         # if the item was previously listed and was bold, or if it wasn't previously listed at all, make it bold
                                         item_text.bold = (update_highlights and (item_name in bold_item_labels or item_name not in existing_item_labels))

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -224,14 +224,14 @@ class ManualContext(SuperContext):
     def get_location_description_by_id(self, id) -> str|None:
         # First we try to get it from slotdata for dynamic descriptions
         description = self.location_id_to_description.get(str(id), None)
-        # Secondly we try to get it from the world itself for a more static alias
-        if description is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
-            description = AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
+        # Secondly we try to get it from the world itself for a more static description
+        if description is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_description"):
+            description = AutoWorldRegister.world_types[self.game].location_id_to_description.get(id, None)
         return description
 
     def get_item_description_by_id(self, id) -> str|None:
         description = self.item_id_to_description.get(str(id), None)
-        if description is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_alias"):
+        if description is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_description"):
             description = AutoWorldRegister.world_types[self.game].item_id_to_description.get(id, None)
         return description
 
@@ -297,8 +297,8 @@ class ManualContext(SuperContext):
                         self.set_deathlink = True
                         self.last_death_link = 0
                     self.visible_events = args['slot_data'].get('visible_events', {})
-                    self.location_id_to_description = args['slot_data'].get('location_id_to_alias', {})
-                    self.item_id_to_description = args['slot_data'].get('item_id_to_alias', {})
+                    self.location_id_to_description = args['slot_data'].get('location_id_to_description', {})
+                    self.item_id_to_description = args['slot_data'].get('item_id_to_description', {})
                     logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -148,8 +148,8 @@ class ManualContext(SuperContext):
     deathlink_out = False
 
     visible_events: dict[str, dict[str, Any]]  = {}
-    location_id_to_alias: dict[str, str] = {}
-    item_id_to_alias: dict[str, str] = {}
+    location_id_to_description: dict[str, str] = {}
+    item_id_to_description: dict[str, str] = {}
 
     search_term = ""
     items_sorting = SortingOrderItem.default.name
@@ -221,19 +221,19 @@ class ManualContext(SuperContext):
         from .Game import game_name  # This will at least give us the name of a manual they've installed
         return Utils.persistent_load().get("client", {}).get("last_manual_game", None) or game_name
 
-    def get_location_alias_by_id(self, id) -> str|None:
-        # First we try to get it from slotdata for dynamic aliases
-        alias = self.location_id_to_alias.get(str(id), None)
+    def get_location_description_by_id(self, id) -> str|None:
+        # First we try to get it from slotdata for dynamic descriptions
+        description = self.location_id_to_description.get(str(id), None)
         # Secondly we try to get it from the world itself for a more static alias
-        if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
-            alias = AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
-        return alias
+        if description is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_alias"):
+            description = AutoWorldRegister.world_types[self.game].location_id_to_alias.get(id, None)
+        return description
 
-    def get_item_alias_by_id(self, id) -> str|None:
-        alias = self.item_id_to_alias.get(str(id), None)
-        if alias is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_alias"):
-            alias = AutoWorldRegister.world_types[self.game].item_id_to_alias.get(id, None)
-        return alias
+    def get_item_description_by_id(self, id) -> str|None:
+        description = self.item_id_to_description.get(str(id), None)
+        if description is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_alias"):
+            description = AutoWorldRegister.world_types[self.game].item_id_to_description.get(id, None)
+        return description
 
     def get_location_by_name(self, name) -> dict[str, Any]:
         location = self.location_table.get(name)
@@ -297,8 +297,8 @@ class ManualContext(SuperContext):
                         self.set_deathlink = True
                         self.last_death_link = 0
                     self.visible_events = args['slot_data'].get('visible_events', {})
-                    self.location_id_to_alias = args['slot_data'].get('location_id_to_alias', {})
-                    self.item_id_to_alias = args['slot_data'].get('item_id_to_alias', {})
+                    self.location_id_to_description = args['slot_data'].get('location_id_to_alias', {})
+                    self.item_id_to_description = args['slot_data'].get('item_id_to_alias', {})
                     logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()
@@ -409,7 +409,7 @@ class ManualContext(SuperContext):
             item_id: int|None = None
             item_count: int = 1
             item_name: str = ""
-            item_alias: str = ""
+            item_description: str = ""
 
         class TreeViewScrollView(ScrollView, TreeViewNode):
             pass
@@ -883,7 +883,7 @@ class ManualContext(SuperContext):
                     for location_id in self.listed_locations[location_category]:
                         has_hint = location_id in hinted_locations or location_id in scoutable_locations
 
-                        extra = f' ({alias})' if (alias := self.ctx.get_location_alias_by_id(location_id)) is not None else ''
+                        extra = f' ({description})' if (description := self.ctx.get_location_description_by_id(location_id)) is not None else ''
                         text = f"{self.ctx.location_names.lookup_in_game(location_id)}{extra}"
                         location_button = TreeViewButton(text=text, size_hint=(.75 if has_hint else 1, None), height=30)
                         location_button.bind(on_release=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
@@ -907,7 +907,7 @@ class ManualContext(SuperContext):
                     #     ("category" not in victory_location_data and location_category == "(No Category)"):
                     if location_category in victory_categories:
                         # Add the Victory location to be marked at any point, which is why locations length has 1 added to it above
-                        extra = f' ({alias})' if (alias := self.ctx.get_location_alias_by_id(victory_location["id"])) is not None else ''
+                        extra = f' ({description})' if (description := self.ctx.get_location_description_by_id(victory_location["id"])) is not None else ''
                         victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"] + extra
                         location_button = TreeViewButton(text=victory_text, size_hint=(1, None), height=dp(30), width=dp(400))
                         location_button.victory = True
@@ -1009,7 +1009,7 @@ class ManualContext(SuperContext):
                                             bold_item_labels.append(item_name)
                                             item.item_count = item_count
 
-                                        item.text="%s %s(%s)" % (item_name, item.item_alias, item_count)
+                                        item.text="%s %s(%s)" % (item_name, item.item_description, item_count)
 
                                         existing_item_labels.append(item_name)
 
@@ -1055,13 +1055,13 @@ class ManualContext(SuperContext):
 
                                     if category_name in item_data["category"] and network_item not in self.listed_items[category_name]:
                                         item_count = len(list(i for i in self.ctx.items_received if i.item == network_item))
-                                        alias = f'({alias}) ' if (alias := self.ctx.get_item_alias_by_id(network_item)) is not None else ''
-                                        item_text = ItemLabel(text="%s %s(%s)" % (item_name, alias, item_count),
+                                        description = f'({description}) ' if (description := self.ctx.get_item_description_by_id(network_item)) is not None else ''
+                                        item_text = ItemLabel(text="%s %s(%s)" % (item_name, description, item_count),
                                                     size_hint=(None, None), height=dp(30), width=dp(400), bold=True)
                                         item_text.item_name = item_name
                                         item_text.item_count = item_count
                                         item_text.item_id = network_item
-                                        item_text.item_alias = alias
+                                        item_text.item_description = description
 
                                         # if the item was previously listed and was bold, or if it wasn't previously listed at all, make it bold
                                         item_text.bold = (update_highlights and (item_name in bold_item_labels or item_name not in existing_item_labels))

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -148,8 +148,8 @@ class ManualContext(SuperContext):
     deathlink_out = False
 
     visible_events: dict[str, dict[str, Any]]  = {}
-    location_id_to_description: dict[str, str] = {}
-    item_id_to_description: dict[str, str] = {}
+    location_name_to_description: dict[str, str] = {}
+    item_name_to_description: dict[str, str] = {}
 
     search_term = ""
     items_sorting = SortingOrderItem.default.name
@@ -221,18 +221,18 @@ class ManualContext(SuperContext):
         from .Game import game_name  # This will at least give us the name of a manual they've installed
         return Utils.persistent_load().get("client", {}).get("last_manual_game", None) or game_name
 
-    def get_location_description_by_id(self, id) -> str|None:
+    def get_location_description_by_name(self, name: str) -> str|None:
         # First we try to get it from slotdata for dynamic descriptions
-        description = self.location_id_to_description.get(str(id), None)
+        description = self.location_name_to_description.get(name, None)
         # Secondly we try to get it from the world itself for a more static description
-        if description is None and hasattr(AutoWorldRegister.world_types[self.game], "location_id_to_description"):
-            description = AutoWorldRegister.world_types[self.game].location_id_to_description.get(id, None)
+        if description is None:
+            description = AutoWorldRegister.world_types[self.game].web.location_descriptions.get(name, None)
         return description
 
-    def get_item_description_by_id(self, id) -> str|None:
-        description = self.item_id_to_description.get(str(id), None)
-        if description is None and hasattr(AutoWorldRegister.world_types[self.game], "item_id_to_description"):
-            description = AutoWorldRegister.world_types[self.game].item_id_to_description.get(id, None)
+    def get_item_description_by_name(self, name: str) -> str|None:
+        description = self.item_name_to_description.get(name, None)
+        if description is None:
+            description = AutoWorldRegister.world_types[self.game].web.item_descriptions.get(name, None)
         return description
 
     def get_location_by_name(self, name) -> dict[str, Any]:
@@ -297,8 +297,8 @@ class ManualContext(SuperContext):
                         self.set_deathlink = True
                         self.last_death_link = 0
                     self.visible_events = args['slot_data'].get('visible_events', {})
-                    self.location_id_to_description = args['slot_data'].get('location_id_to_description', {})
-                    self.item_id_to_description = args['slot_data'].get('item_id_to_description', {})
+                    self.location_name_to_description = args['slot_data'].get('location_name_to_description', {})
+                    self.item_name_to_description = args['slot_data'].get('item_name_to_description', {})
                     logger.info(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()
@@ -882,13 +882,13 @@ class ManualContext(SuperContext):
 
                     for location_id in self.listed_locations[location_category]:
                         has_hint = location_id in hinted_locations or location_id in scoutable_locations
-
-                        extra = f' ({description})' if (description := self.ctx.get_location_description_by_id(location_id)) is not None else ''
-                        text = f"{self.ctx.location_names.lookup_in_game(location_id)}{extra}"
+                        location_name = self.ctx.location_names.lookup_in_game(location_id)
+                        extra = f' ({description})' if (description := self.ctx.get_location_description_by_name(location_name)) is not None else ''
+                        text = f"{location_name}{extra}"
                         location_button = TreeViewButton(text=text, size_hint=(.75 if has_hint else 1, None), height=30)
                         location_button.bind(on_release=lambda *args, loc_id=location_id: self.location_button_callback(loc_id, *args))
                         location_button.id = location_id
-                        location_button.location_name = self.ctx.location_names.lookup_in_game(location_id)
+                        location_button.location_name = location_name
                         category_layout.add_widget(location_button)
 
                         if location_id in hinted_locations:
@@ -907,11 +907,12 @@ class ManualContext(SuperContext):
                     #     ("category" not in victory_location_data and location_category == "(No Category)"):
                     if location_category in victory_categories:
                         # Add the Victory location to be marked at any point, which is why locations length has 1 added to it above
-                        extra = f' ({description})' if (description := self.ctx.get_location_description_by_id(victory_location["id"])) is not None else ''
-                        victory_text: str = "VICTORY! (seed finished)" if victory_location["name"] == "__Manual Game Complete__" else "GOAL: " + victory_location["name"] + extra
+                        location_name = victory_location["name"]
+                        extra = f' ({description})' if (description := self.ctx.get_location_description_by_name(location_name)) is not None else ''
+                        victory_text: str = "VICTORY! (seed finished)" if location_name == "__Manual Game Complete__" else "GOAL: " + location_name + extra
                         location_button = TreeViewButton(text=victory_text, size_hint=(1, None), height=dp(30), width=dp(400))
                         location_button.victory = True
-                        location_button.location_name = victory_location["name"]
+                        location_button.location_name = location_name
                         location_button.bind(on_release=self.victory_button_callback)
                         category_layout.add_widget(location_button)
 
@@ -1055,7 +1056,7 @@ class ManualContext(SuperContext):
 
                                     if category_name in item_data["category"] and network_item not in self.listed_items[category_name]:
                                         item_count = len(list(i for i in self.ctx.items_received if i.item == network_item))
-                                        description = f'({description}) ' if (description := self.ctx.get_item_description_by_id(network_item)) is not None else ''
+                                        description = f'({description}) ' if (description := self.ctx.get_item_description_by_name(item_name)) is not None else ''
                                         item_text = ItemLabel(text="%s %s(%s)" % (item_name, description, item_count),
                                                     size_hint=(None, None), height=dp(30), width=dp(400), bold=True)
                                         item_text.item_name = item_name

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -299,7 +299,7 @@ class ManualContext(SuperContext):
                     self.visible_events = args['slot_data'].get('visible_events', {})
                     self.location_name_to_description = args['slot_data'].get('location_name_to_description', {})
                     self.item_name_to_description = args['slot_data'].get('item_name_to_description', {})
-                    logger.info(f"Slot data: {args['slot_data']}")
+                    logger.debug(f"Slot data: {args['slot_data']}")
 
             self.ui.build_tracker_and_locations_table()
             self.ui.request_update_tracker_and_locations_table(update_highlights=True)

--- a/src/Meta.py
+++ b/src/Meta.py
@@ -28,8 +28,14 @@ def set_world_description(base_doc: str) -> str:
     return base_doc
 
 
-def set_world_webworld(web: WebWorld) -> WebWorld:
+def set_world_webworld(web: ManualWeb) -> ManualWeb:
     from .Options import make_options_group
+    from .Locations import  location_name_to_description
+    from .Items import  item_name_to_description
+
+    web.location_descriptions = location_name_to_description
+    web.item_descriptions = item_name_to_description
+
     if meta_table.get("docs", {}).get("web", {}):
         Web_Config = meta_table["docs"]["web"]
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -51,10 +51,10 @@ class ManualWorld(World):
     category_table = category_table
 
     item_id_to_name = item_id_to_name
+    item_id_to_description = item_id_to_description
     item_name_to_id = item_name_to_id
     item_name_to_item = item_name_to_item
     item_name_groups = item_name_groups
-    item_id_to_alias = item_id_to_description # check location_id_to_alias for why its named this way
 
     filler_item_name = filler_item_name
 
@@ -63,16 +63,17 @@ class ManualWorld(World):
     start_inventory = {}
 
     location_id_to_name = location_id_to_name
+    location_id_to_description = location_id_to_description
     location_name_to_id = location_name_to_id
     location_name_to_location = location_name_to_location
     location_name_groups = location_name_groups
-    location_id_to_alias = location_id_to_description # by naming it this way, the description will also display in the UT Tracker tab
     victory_names = victory_names
 
     event_name_to_event = event_name_to_event
 
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True
+    location_id_to_alias = location_id_to_description
 
     origin_region_name = "Manual"
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,8 +10,8 @@ from worlds.LauncherComponents import Component, SuffixIdentifier, components, T
 from .Data import item_table, location_table, event_table, region_table, category_table
 from .Game import game_name, filler_item_name, starting_items
 from .Meta import world_description, world_webworld
-from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups, victory_names, event_name_to_event
-from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups
+from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups, victory_names, event_name_to_event, location_id_to_description
+from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups, item_id_to_description
 from .DataValidation import runGenerationDataValidation, runPreFillDataValidation
 
 from .Regions import create_regions, create_events
@@ -54,6 +54,7 @@ class ManualWorld(World):
     item_name_to_id = item_name_to_id
     item_name_to_item = item_name_to_item
     item_name_groups = item_name_groups
+    item_id_to_alias = item_id_to_description # check location_id_to_alias for why its named this way
 
     filler_item_name = filler_item_name
 
@@ -65,14 +66,13 @@ class ManualWorld(World):
     location_name_to_id = location_name_to_id
     location_name_to_location = location_name_to_location
     location_name_groups = location_name_groups
+    location_id_to_alias = location_id_to_description # by naming it this way, the description will also display in the UT Tracker tab
     victory_names = victory_names
 
     event_name_to_event = event_name_to_event
 
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True
-    location_id_to_alias: dict[int, str] = {}
-    item_id_to_alias: dict[int, str] = {}
 
     origin_region_name = "Manual"
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,8 +10,8 @@ from worlds.LauncherComponents import Component, SuffixIdentifier, components, T
 from .Data import item_table, location_table, event_table, region_table, category_table
 from .Game import game_name, filler_item_name, starting_items
 from .Meta import world_description, world_webworld
-from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups, victory_names, event_name_to_event, location_id_to_description
-from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups, item_id_to_description
+from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups, victory_names, event_name_to_event, location_name_to_description
+from .Items import item_id_to_name, item_name_to_id, item_name_to_item, item_name_groups
 from .DataValidation import runGenerationDataValidation, runPreFillDataValidation
 
 from .Regions import create_regions, create_events
@@ -51,7 +51,6 @@ class ManualWorld(World):
     category_table = category_table
 
     item_id_to_name = item_id_to_name
-    item_id_to_description = item_id_to_description
     item_name_to_id = item_name_to_id
     item_name_to_item = item_name_to_item
     item_name_groups = item_name_groups
@@ -63,7 +62,6 @@ class ManualWorld(World):
     start_inventory = {}
 
     location_id_to_name = location_id_to_name
-    location_id_to_description = location_id_to_description
     location_name_to_id = location_name_to_id
     location_name_to_location = location_name_to_location
     location_name_groups = location_name_groups
@@ -73,7 +71,7 @@ class ManualWorld(World):
 
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True
-    location_id_to_alias = location_id_to_description
+    location_id_to_alias: dict[int, str] = {location_name_to_id[name]: desc for name, desc in location_name_to_description.items()}
 
     origin_region_name = "Manual"
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -71,6 +71,9 @@ class ManualWorld(World):
 
     # UT (the universal-est of trackers) can now generate without a YAML
     ut_can_gen_without_yaml = True
+    location_id_to_alias: dict[int, str] = {}
+    item_id_to_alias: dict[int, str] = {}
+
     origin_region_name = "Manual"
 
     def get_filler_item_name(self) -> str:


### PR DESCRIPTION
## Added for both items.json and locations.json:
- A new optionnal string property: `description`
  - anything written in it will be displayed on the client next to the object name (see pictures below)
  - its done in such a way that location description also get added in the Tracker tab (location_id_to_alias in init.py)
  - A more dynamic description can also be added by hooks via slotdata for both location_name_to_description and item_name_to_description

Someone that knows more about kivy could potentially move the description below the item/location name but thats not something I know how to do other than maybe adding a \n

The following example pictures shows my Old OuterWilds manual using those aliases to protect against spoilers
<img width="1169" height="124" alt="image" src="https://github.com/user-attachments/assets/d25e851b-8578-4035-87d2-124c098ad7bc" />

<details><summary>old header</summary>
<p>
Used to be part of #214 now standalone and with a real implementation with it
it will require #214 to be merged before this one since this branch is based on it
</p>
</details> 