### PR TITLE
Use `getattr` instead of `hasattr` to check for UT generation

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -254,7 +254,7 @@ class ManualWorld(World):
         precollected_items = list(self.multiworld.precollected_items[self.player])
 
         # UT doesn't precollect the exceptions so this can be skipped
-        if not hasattr(self.multiworld, "generation_is_fake"):
+        if not getattr(self.multiworld, "generation_is_fake", False):
             precollected_exceptions = self.options.start_inventory.value + self.options.start_inventory_from_pool.value # type: ignore
             for item, count in precollected_exceptions.items():
                 items_iter = iter([i for i in precollected_items if i.name == item])


### PR DESCRIPTION
replace `hasattr()` check for UT with `getattr()` since apparently they'll add it to core AP and make it return `false` unless UT make it `true`
[(source main AP discord: UT channel)](https://discord.com/channels/731205301247803413/1367270230635839539/1522811310008438825)