### PR TITLE
Death Link Description Fix

### DIFF
--- a/src/Options.py
+++ b/src/Options.py
@@ -21,6 +21,9 @@ class GenerateRegionDiagram(Toggle):
     """Generate a region diagram."""
     visibility = Visibility.none  # Hidden option
 
+class ManualDeathLink(DeathLink):
+    pass
+
 def createChoiceOptions(values: dict, aliases: dict) -> dict:
     values = {'option_' + i: v for i, v in values.items()}
     aliases = {'alias_' + i: v for i, v in aliases.items()}
@@ -82,7 +85,7 @@ if any(item.get('trap') for item in item_table):
     manual_options["filler_traps"] = FillerTrapPercent
 
 if game_table.get("death_link"):
-    manual_options["death_link"] = DeathLink
+    manual_options["death_link"] = ManualDeathLink
 
 
 ######################


### PR DESCRIPTION
When using `options.json` to modify the `death_link` option, Manual copies Archipelago' `DeathLink` class _itself_ to the `manual_options` dict. It is this class that gets modified when, say, adding a description to the option. Since Archipelago's base class is modified, the modification is copied to all of the player's other APWorlds.

For example, my description from Manual_LEGORacers2_Nixill:
```yaml
  death_link:
    # Enable death link?
    # 
    # Send a death whenever you lose, reset, or leave any race or minigame,
    # or if your game crashes.
    # 
    # If you receive a death during a race or minigame, restart that race or
    # minigame immediately.
    'false': 50
    'true': 0
```

... can be seen in A Link to the Past:
```yaml
  death_link:
    # Enable death link?
    # 
    # Send a death whenever you lose, reset, or leave any race or minigame,
    # or if your game crashes.
    # 
    # If you receive a death during a race or minigame, restart that race or
    # minigame immediately.
    'false': 50
    'true': 0
```

... or Blasphemous:
```yaml
  death_link:
    # Enable death link?
    # 
    # Send a death whenever you lose, reset, or leave any race or minigame,
    # or if your game crashes.
    # 
    # If you receive a death during a race or minigame, restart that race or
    # minigame immediately.
    # 
    # Note that Guilt Fragments will not appear when killed by death link.
    'false': 50
    'true': 0
```

... or other Manuals like Euro Truck Simulator 2:
```yaml
  death_link:
    # Enable death link?
    # 
    # Send a death whenever you lose, reset, or leave any race or minigame,
    # or if your game crashes.
    # 
    # If you receive a death during a race or minigame, restart that race or
    # minigame immediately.
    'false': 50
    'true': 0
```

This pull request fixes that by creating a subclass of DeathLink and modifying *that* instead.