### PR TITLE
Reword pin documentation

### DIFF
--- a/docs/design/when-youre-done.md
+++ b/docs/design/when-youre-done.md
@@ -6,5 +6,5 @@ With the world done, you have little left to do in terms of design or decisions.
 If you want others to play your manual world as well, your template .yaml, .apworld and documentation need to reach players. You can create a thread in our Discord in the #video-games, #board-card-games or #meta-games for it. Your documentation can all go in the thread, but this can lack portability of your Manual. As such, I would recommend providing one .ZIP file download for all your files, including your .yaml and .apworld, but especially any other external tools or docs necessary to play the Manual. Even better would be to set up a GitHub repository for your apworld(s)!
   
 ## Pinning
-With your thread made and your Manual distributed, you can also request to have important messages in your thread pinned by pinging the @Moderators role in our Discord from that thread.
+With your thread made and your Manual distributed, you can pin important messages in your thread by right-clicking on them and selecting Pin Message.
 


### PR DESCRIPTION
Requesting moderators to pin messages in implementation threads has been unnecessary for over 9 months as of writing, as all users have been able to pin messages in the threads since November 1st, 2025. Therefore, the part of the documentation mentioning it can instead just tell users how to pin their own messages.

One could argue that this part of the documentation is instead completely unnecessary, but as it continues to be different to how pinning works in the main Archipelago server and is not intuitive to users, I believe it is still worth including in the documentation.

There could also be a mention of how to pin messages on mobile but I'm not sure how to phrase that offhand and I don't think it would be applicable to most users anyway.