### PR TITLE
Minor Client tweaks

### DIFF
--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -179,8 +179,10 @@ class ManualContext(SuperContext):
 
         self.send_index: int = 0
         self.syncing = False
-        self.game: str = game
+        self.game = game
         self.username = player_name
+        self.locations_checked: list[int] = []
+        self.locations_scouted: list[int] = []
 
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -1273,7 +1273,7 @@ async def game_watcher_manual(ctx: ManualContext):
         if ctx.syncing == True:
             sync_msg = [{'cmd': 'Sync'}]
             if ctx.locations_checked:
-                sync_msg.append({"cmd": "LocationChecks", "locations": list(ctx.locations_checked)})
+                ctx.check_locations(ctx.locations_checked)
             if ctx.locations_scouted:
                 sync_msg.append({"cmd": "LocationScouts", "locations": list(ctx.locations_scouted), "create_as_hint": 2})
             await ctx.send_msgs(sync_msg)

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -1273,12 +1273,13 @@ async def game_watcher_manual(ctx: ManualContext):
             ctx.ui.check_for_requested_update()
 
         if ctx.syncing == True:
-            sync_msg = [{'cmd': 'Sync'}]
+            sync_msg = []
             if ctx.locations_checked:
                 ctx.check_locations(ctx.locations_checked)
             if ctx.locations_scouted:
                 sync_msg.append({"cmd": "LocationScouts", "locations": list(ctx.locations_scouted), "create_as_hint": 2})
-            await ctx.send_msgs(sync_msg)
+            if sync_msg:
+                await ctx.send_msgs(sync_msg)
             ctx.syncing = False
 
         if ctx.set_deathlink:

--- a/src/ManualClient.py
+++ b/src/ManualClient.py
@@ -1275,7 +1275,7 @@ async def game_watcher_manual(ctx: ManualContext):
         if ctx.syncing == True:
             sync_msg = []
             if ctx.locations_checked:
-                ctx.check_locations(ctx.locations_checked)
+                await ctx.check_locations(ctx.locations_checked)
             if ctx.locations_scouted:
                 sync_msg.append({"cmd": "LocationScouts", "locations": list(ctx.locations_scouted), "create_as_hint": 2})
             if sync_msg:


### PR DESCRIPTION
I've been doing an audit of Best Practices across a bunch of my worlds, and I noticed that Manual is doing a couple things that are very much "This was written in 2023 and never looked at since"

This PR does a couple very small things:

1. Use [`CommonContext.check_locations`](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.7/CommonClient.py#L530) instead of building the LocationChecks packet directly.
2. Don't send [`Sync`](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.7/MultiServer.py#L2000) packets.  Sync asks for a full recap of every item from Index 0.   Generally it's only needed if the client detects a desync and needs to reset the whole inventory.  I'm not sure why we're doing this, but we don't need to, and it wastes a decent amount of bandwidth.