### PR TITLE
Missing comma in regions.md

### DIFF
--- a/docs/syntax/regions.md
+++ b/docs/syntax/regions.md
@@ -62,7 +62,7 @@ Here's an example that connects from the "Overworld" starting region to the "Net
 ```json
 {
     "Overworld": {
-        "starting": true
+        "starting": true,
         "connects_to": ["Nether"]
     },
     "Nether": {


### PR DESCRIPTION
There is a comma missing in an example code block in the documentation