### PR TITLE
Schema: add scoutable to the locations schema

### DIFF
--- a/schemas/Manual.locations.schema.json
+++ b/schemas/Manual.locations.schema.json
@@ -92,6 +92,11 @@
                     "type": "boolean",
                     "default": false
                 },
+                "scoutable": {
+                    "description": "(Optional) Adds a button on the client to scout (free hint) this location",
+                    "type": "boolean",
+                    "default": false
+                },
                 "hint_entrance": {
                     "description": "(Optional) Adds additional text to this location's hints to convey useful information. Typically used for entrance randomization.",
                     "type": "string"


### PR DESCRIPTION
Seems we forgot to add "scoutable" to the schema when that feature got added