### PR TITLE
Add documentation about PopTracker

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ _How does that work?!_ Well, you'll just have to read more below!
 
 - [Manual Builder](resources/manual-builder.md)
 - [JSON Schemas for World Developers](resources/json-schemas-for-world-devs.md)
+- [PopTracker](resources/poptracker.md)
 - [Visualizing Your World Logic](resources/visualizing-your-world-logic.md)
 - [User-Created Tools](resources/user-created-tools.md)
 

--- a/docs/resources/manual-builder.md
+++ b/docs/resources/manual-builder.md
@@ -1,4 +1,5 @@
 # Manual Builder
+
 We get that the syntax for making a Manual world can be a bit daunting... so we've made a tool to get you started easier!
 
 The Manual Builder is a web-based tool that lets you add lists of items and locations for your game in plain text. It also includes a number of helpful tooltips to explain what the options in the tool are used for.
@@ -10,6 +11,7 @@ You can find the Manual Builder here: https://manualforarchipelago.github.io/Man
 The Builder tends to lag behind official features a bit so, once you're nicely acclimated to the Manual world creation process, you'll want to take a look at our [Syntax Reference and Examples](../README.md#syntax-reference-and-examples) section for next steps!
 
 ## Reporting Bugs or Requesting Features
+
 If you encounter any bugs with the Builder, be sure to let us know in the [official Manual Discord](https://discord.gg/T5bcsVHByx) in the #manual-support channel!
 
 If there are any features you'd like to see in the Builder, hop into that same Discord above and tell us about your desired feature in the #feature-suggestions forum there!

--- a/docs/resources/poptracker.md
+++ b/docs/resources/poptracker.md
@@ -6,7 +6,7 @@ PopTracker is a well-loved tracker used when playing a variety of AP worlds, and
 
 CodeGorilla has created an awesome tool to automatically* create a PopTracker pack from a Manual world! Learn more in the [AP Manual to PopTracker thread](https://discord.com/channels/1097532591650910289/1401709372945731664) in our Discord. (You must have joined the Manual Discord server to view this.)
 
-* This tool does a lot of the heavy-lifting to make the PopTracker pack, but you may need to customize some parts by hand to finish it up.
+\* This tool does a lot of the heavy-lifting to make the PopTracker pack, but you may need to customize some parts by hand to finish it up.
 
 ## PopTracker as a Manual client
 

--- a/docs/resources/poptracker.md
+++ b/docs/resources/poptracker.md
@@ -1,0 +1,17 @@
+# PopTracker
+
+PopTracker is a well-loved tracker used when playing a variety of AP worlds, and you can use it when playing Manual worlds too!
+
+## Auto-Generating a PopTracker pack for a Manual world
+
+CodeGorilla has created an awesome tool to automatically* create a PopTracker pack from a Manual world! Learn more in the [AP Manual to PopTracker thread](https://discord.com/channels/1097532591650910289/1401709372945731664) in our Discord. (You must have joined the Manual Discord server to view this.)
+
+* This tool does a lot of the heavy-lifting to make the PopTracker pack, but you may need to customize some parts by hand to finish it up.
+
+## PopTracker as a Manual client
+
+PopTracker can also function as a Manual client by sending locations when they're clicked!
+
+The tool linked above sets this up for you automatically when used. 
+
+If you're setting this up for your own custom-made PopTracker pack, you'll want to [join the PopTracker Discord](https://discord.com/invite/gwThqMCPgK) to learn more about the location mapping you need to create.


### PR DESCRIPTION
Suggested documentation addition from this PR comment: https://github.com/ManualForArchipelago/Manual/pull/220#issuecomment-5297403408

Most people don't know that PopTracker can function as an alternative Manual client, so this documentation mentions that. Also takes the opportunity to point out CodeGorilla's awesome tool for creating PopTracker packs from Manuals.