### PR TITLE
add a doc string to ManualDeathLink

### DIFF
--- a/src/Options.py
+++ b/src/Options.py
@@ -22,7 +22,7 @@ class GenerateRegionDiagram(Toggle):
     visibility = Visibility.none  # Hidden option
 
 class ManualDeathLink(DeathLink):
-    pass
+    """When you die, everyone who enabled death link dies. Of course, the reverse is true too."""
 
 def createChoiceOptions(values: dict, aliases: dict) -> dict:
     values = {'option_' + i: v for i, v in values.items()}


### PR DESCRIPTION
According to Archipelago's Unit tests Deathlink should always have a doc string
In some situation the base doc string doesnt load properly and fail tests,
just adding the default string here fixes it